### PR TITLE
WB-80-api-server

### DIFF
--- a/src/main/java/com/watermelon/server/randomevent/parts/controller/PartsController.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/controller/PartsController.java
@@ -1,15 +1,19 @@
 package com.watermelon.server.randomevent.parts.controller;
 
 import com.watermelon.server.randomevent.auth.annotations.Uid;
+import com.watermelon.server.randomevent.parts.dto.response.ResponseMyPartsListDto;
 import com.watermelon.server.randomevent.parts.dto.response.ResponsePartsDrawDto;
 import com.watermelon.server.randomevent.parts.exception.PartsDrawLimitExceededException;
 import com.watermelon.server.randomevent.parts.service.PartsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +31,13 @@ public class PartsController {
         }catch (PartsDrawLimitExceededException e){
             return new ResponseEntity<>(HttpStatus.TOO_MANY_REQUESTS);
         }
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ResponseMyPartsListDto>> getMyPartsList(
+            @Uid String uid
+    ){
+        return new ResponseEntity<>(partsService.getMyParts(uid), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/watermelon/server/randomevent/parts/domain/Parts.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/domain/Parts.java
@@ -1,9 +1,6 @@
 package com.watermelon.server.randomevent.parts.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +22,8 @@ public class Parts {
 
     private String description;
 
-    private String category;
+    @Enumerated(EnumType.STRING)
+    private PartsCategory category;
 
     private String imgSrc;
 

--- a/src/main/java/com/watermelon/server/randomevent/parts/domain/PartsCategory.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/domain/PartsCategory.java
@@ -1,0 +1,5 @@
+package com.watermelon.server.randomevent.parts.domain;
+
+public enum PartsCategory {
+    COLOR, REAR, DRIVE_MODE, WHEEL
+}

--- a/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponseMyPartsListDto.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponseMyPartsListDto.java
@@ -1,9 +1,15 @@
 package com.watermelon.server.randomevent.parts.dto.response;
 
+import com.watermelon.server.randomevent.parts.domain.LotteryApplierParts;
+import com.watermelon.server.randomevent.parts.domain.Parts;
+import com.watermelon.server.randomevent.parts.domain.PartsCategory;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
@@ -31,6 +37,39 @@ public class ResponseMyPartsListDto {
                 ))
                 .build()
         );
+    }
+
+    /**
+     * 응모자 파츠 리스트를 카테고리 별로 분류해서 반환한다.
+     * @param lotteryApplierPartsList 응모자 파츠 리스트
+     * @return 응모자의 파츠 리스트
+     */
+    public static List<ResponseMyPartsListDto> createDtoListByCategory(List<LotteryApplierParts> lotteryApplierPartsList) {
+
+        PartsCategory[] categories = PartsCategory.values();
+        Map<PartsCategory, List<ResponsePartsListDto>> map = new HashMap<>();
+
+        for (PartsCategory partsCategory : categories) {
+            map.put(partsCategory, new ArrayList<>());
+        }
+
+        for(LotteryApplierParts lotteryApplierParts : lotteryApplierPartsList){
+            Parts parts = lotteryApplierParts.getParts();
+            map.get(parts.getCategory()).add(ResponsePartsListDto.from(parts, lotteryApplierParts.isEquipped()));
+        }
+
+        List<ResponseMyPartsListDto> responseMyPartsListDtos = new ArrayList<>();
+        for(PartsCategory partsCategory : categories){
+            responseMyPartsListDtos.add(
+                    new ResponseMyPartsListDto(
+                            partsCategory.toString(),
+                            map.get(partsCategory)
+                    )
+            );
+        }
+
+        return responseMyPartsListDtos;
+
     }
 
 }

--- a/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponseMyPartsListDto.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponseMyPartsListDto.java
@@ -1,0 +1,36 @@
+package com.watermelon.server.randomevent.parts.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ResponseMyPartsListDto {
+
+    private String category;
+    List<ResponsePartsListDto> parts;
+
+    public static List<ResponseMyPartsListDto> createTestDtoList() {
+        return List.of(
+                ResponseMyPartsListDto.builder()
+                .category("color")
+                .parts(List.of(
+                        ResponsePartsListDto.any(),
+                        ResponsePartsListDto.any(),
+                        ResponsePartsListDto.any()
+                ))
+                .build(),
+        ResponseMyPartsListDto.builder()
+                .category("rear")
+                .parts(List.of(
+                        ResponsePartsListDto.any(),
+                        ResponsePartsListDto.any(),
+                        ResponsePartsListDto.any()
+                ))
+                .build()
+        );
+    }
+
+}

--- a/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponsePartsDrawDto.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponsePartsDrawDto.java
@@ -27,7 +27,7 @@ public class ResponsePartsDrawDto {
 
     public static ResponsePartsDrawDto from(Parts parts, boolean isEquipped){
         return ResponsePartsDrawDto.builder()
-                .category(parts.getCategory())
+                .category(parts.getCategory().toString())
                 .partsId(parts.getId())
                 .name(parts.getName())
                 .imgSrc(parts.getImgSrc())

--- a/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponsePartsListDto.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponsePartsListDto.java
@@ -1,5 +1,6 @@
 package com.watermelon.server.randomevent.parts.dto.response;
 
+import com.watermelon.server.randomevent.parts.domain.Parts;
 import lombok.Builder;
 import lombok.Data;
 
@@ -22,6 +23,17 @@ public class ResponsePartsListDto {
                 .description("any")
                 .imgSrc("any")
                 .isEquipped(false)
+                .build();
+    }
+
+    public static ResponsePartsListDto from(Parts parts, boolean isEquipped){
+        return ResponsePartsListDto.builder()
+                .category(parts.getCategory().toString())
+                .partsId(parts.getId())
+                .name(parts.getName())
+                .description(parts.getDescription())
+                .imgSrc(parts.getImgSrc())
+                .isEquipped(isEquipped)
                 .build();
     }
 

--- a/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponsePartsListDto.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/dto/response/ResponsePartsListDto.java
@@ -1,0 +1,28 @@
+package com.watermelon.server.randomevent.parts.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ResponsePartsListDto {
+
+    private String category;
+    private Long partsId;
+    private String name;
+    private String description;
+    private String imgSrc;
+    private boolean isEquipped;
+
+    public static ResponsePartsListDto any(){
+        return ResponsePartsListDto.builder()
+                .partsId(1L)
+                .category("any")
+                .name("any")
+                .description("any")
+                .imgSrc("any")
+                .isEquipped(false)
+                .build();
+    }
+
+}

--- a/src/main/java/com/watermelon/server/randomevent/parts/repository/LotteryApplierPartsRepository.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/repository/LotteryApplierPartsRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface LotteryApplierPartsRepository extends JpaRepository<LotteryApplierParts, Long> {
 
     List<LotteryApplierParts> findLotteryApplierPartsByLotteryApplierId(Long lotteryApplierId);
+    List<LotteryApplierParts> findLotteryApplierPartsByLotteryApplierUid(String lotteryApplierUid);
 
 }

--- a/src/main/java/com/watermelon/server/randomevent/parts/service/LotteryApplierPartsService.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/service/LotteryApplierPartsService.java
@@ -4,6 +4,9 @@ import com.watermelon.server.randomevent.domain.LotteryApplier;
 import com.watermelon.server.randomevent.parts.domain.LotteryApplierParts;
 import com.watermelon.server.randomevent.parts.domain.Parts;
 
+import java.util.List;
+
+
 public interface LotteryApplierPartsService {
 
     /**
@@ -14,5 +17,12 @@ public interface LotteryApplierPartsService {
      * @return 응모자-파츠
      */
     LotteryApplierParts addPartsAndGet(LotteryApplier lotteryApplier, Parts parts);
+
+    /**
+     * uid 에 대한 응모자의 응모자-파츠 목록을 반환
+     * @param uid 응모자의 uid
+     * @return 응모자-파츠 목록
+     */
+    List<LotteryApplierParts> getListByApplier(String uid);
 
 }

--- a/src/main/java/com/watermelon/server/randomevent/parts/service/LotteryApplierPartsServiceImpl.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/service/LotteryApplierPartsServiceImpl.java
@@ -7,6 +7,8 @@ import com.watermelon.server.randomevent.parts.repository.LotteryApplierPartsRep
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class LotteryApplierPartsServiceImpl implements LotteryApplierPartsService{
@@ -22,6 +24,11 @@ public class LotteryApplierPartsServiceImpl implements LotteryApplierPartsServic
                 LotteryApplierParts.createApplierParts(isFirst, lotteryApplier, parts)
         );
 
+    }
+
+    @Override
+    public List<LotteryApplierParts> getListByApplier(String uid) {
+        return lotteryApplierPartsRepository.findLotteryApplierPartsByLotteryApplierUid(uid);
     }
 
     /**

--- a/src/main/java/com/watermelon/server/randomevent/parts/service/PartsService.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/service/PartsService.java
@@ -14,6 +14,11 @@ public interface PartsService {
      */
     ResponsePartsDrawDto drawParts(String uid);
 
+    /**
+     * uid 에 대한 유저의 파츠 목록을 dto 형식으로 반환
+     * @param uid uid
+     * @return 유저의 파츠 목록
+     */
     List<ResponseMyPartsListDto> getMyParts(String uid);
 
 }

--- a/src/main/java/com/watermelon/server/randomevent/parts/service/PartsService.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/service/PartsService.java
@@ -1,6 +1,9 @@
 package com.watermelon.server.randomevent.parts.service;
 
+import com.watermelon.server.randomevent.parts.dto.response.ResponseMyPartsListDto;
 import com.watermelon.server.randomevent.parts.dto.response.ResponsePartsDrawDto;
+
+import java.util.List;
 
 public interface PartsService {
 
@@ -10,5 +13,7 @@ public interface PartsService {
      * @return 파츠 뽑기 결과
      */
     ResponsePartsDrawDto drawParts(String uid);
+
+    List<ResponseMyPartsListDto> getMyParts(String uid);
 
 }

--- a/src/main/java/com/watermelon/server/randomevent/parts/service/PartsServiceImpl.java
+++ b/src/main/java/com/watermelon/server/randomevent/parts/service/PartsServiceImpl.java
@@ -3,6 +3,7 @@ package com.watermelon.server.randomevent.parts.service;
 import com.watermelon.server.randomevent.domain.LotteryApplier;
 import com.watermelon.server.randomevent.parts.domain.LotteryApplierParts;
 import com.watermelon.server.randomevent.parts.domain.Parts;
+import com.watermelon.server.randomevent.parts.dto.response.ResponseMyPartsListDto;
 import com.watermelon.server.randomevent.parts.dto.response.ResponsePartsDrawDto;
 import com.watermelon.server.randomevent.parts.exception.PartsNotExistException;
 import com.watermelon.server.randomevent.parts.repository.PartsRepository;
@@ -38,6 +39,13 @@ public class PartsServiceImpl implements PartsService {
         LotteryApplierParts lotteryApplierParts = lotteryApplierPartsService.addPartsAndGet(applier, parts);
 
         return ResponsePartsDrawDto.from(parts, lotteryApplierParts.isEquipped());
+    }
+
+    @Override
+    public List<ResponseMyPartsListDto> getMyParts(String uid) {
+        return ResponseMyPartsListDto.createDtoListByCategory(
+                lotteryApplierPartsService.getListByApplier(uid)
+        );
     }
 
     /**

--- a/src/test/java/com/watermelon/server/randomevent/parts/controller/PartsControllerTest.java
+++ b/src/test/java/com/watermelon/server/randomevent/parts/controller/PartsControllerTest.java
@@ -2,6 +2,7 @@ package com.watermelon.server.randomevent.parts.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.watermelon.server.randomevent.auth.resolver.UidArgumentResolver;
+import com.watermelon.server.randomevent.parts.dto.response.ResponseMyPartsListDto;
 import com.watermelon.server.randomevent.parts.dto.response.ResponsePartsDrawDto;
 import com.watermelon.server.randomevent.parts.exception.PartsDrawLimitExceededException;
 import com.watermelon.server.randomevent.parts.service.PartsService;
@@ -15,9 +16,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static com.watermelon.server.Constants.TEST_UID;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -71,6 +74,31 @@ class PartsControllerTest {
         this.mockMvc.perform(post(PATH)
                         .header(UidArgumentResolver.HEADER_UID, TEST_UID))
                 .andExpect(status().isTooManyRequests())
+                .andDo(document(DOCUMENT_NAME));
+
+    }
+
+    @Test
+    @DisplayName("자신의 파츠 목록을 반환한다.")
+    void getMyPartsList() throws Exception {
+
+        final String PATH = "/event/parts";
+        final String DOCUMENT_NAME = "event/parts/get";
+
+        //given
+        List<ResponseMyPartsListDto> responseMyPartsListDtos = ResponseMyPartsListDto.createTestDtoList();
+
+        Mockito.when(partsService.getMyParts(TEST_UID)).thenReturn(
+            responseMyPartsListDtos
+        );
+
+        String expected = objectMapper.writeValueAsString(responseMyPartsListDtos);
+
+        //when & then
+        this.mockMvc.perform(get(PATH)
+                        .header(UidArgumentResolver.HEADER_UID, TEST_UID))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expected))
                 .andDo(document(DOCUMENT_NAME));
 
     }

--- a/src/test/java/com/watermelon/server/randomevent/parts/dto/response/ResponseMyPartsListDtoTest.java
+++ b/src/test/java/com/watermelon/server/randomevent/parts/dto/response/ResponseMyPartsListDtoTest.java
@@ -1,0 +1,62 @@
+package com.watermelon.server.randomevent.parts.dto.response;
+
+import com.watermelon.server.randomevent.domain.LotteryApplier;
+import com.watermelon.server.randomevent.parts.domain.LotteryApplierParts;
+import com.watermelon.server.randomevent.parts.domain.Parts;
+import com.watermelon.server.randomevent.parts.domain.PartsCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResponseMyPartsListDtoTest {
+
+    @Test
+    @DisplayName("카테고리 별로 분류한다.")
+    void createDtoListByCategory() {
+
+        //given
+        Parts parts1 = Parts.builder()
+                .category(PartsCategory.COLOR)
+                .build();
+
+        Parts parts2 = Parts.builder()
+                .category(PartsCategory.WHEEL)
+                .build();
+
+        LotteryApplier lotteryApplier = new LotteryApplier();
+
+        LotteryApplierParts lotteryApplierParts1 = LotteryApplierParts.createApplierParts(true, lotteryApplier, parts1);
+        LotteryApplierParts lotteryApplierParts2 = LotteryApplierParts.createApplierParts(true, lotteryApplier, parts2);
+
+        List<ResponseMyPartsListDto> expected = List.of(
+                ResponseMyPartsListDto.builder()
+                        .category(PartsCategory.COLOR.toString())
+                        .parts(List.of(ResponsePartsListDto.from(parts1, true)))
+                        .build(),
+                ResponseMyPartsListDto.builder()
+                        .category(PartsCategory.REAR.toString())
+                        .parts(List.of())
+                        .build(),
+                ResponseMyPartsListDto.builder()
+                        .category(PartsCategory.DRIVE_MODE.toString())
+                        .parts(List.of())
+                        .build(),
+                ResponseMyPartsListDto.builder()
+                        .category(PartsCategory.WHEEL.toString())
+                        .parts(List.of(ResponsePartsListDto.from(parts2, true)))
+                        .build()
+        );
+
+        //when
+        List<ResponseMyPartsListDto> actual = ResponseMyPartsListDto.createDtoListByCategory(
+                List.of(lotteryApplierParts1, lotteryApplierParts2)
+        );
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+
+    }
+}

--- a/src/test/java/com/watermelon/server/randomevent/parts/service/LotteryApplierPartsServiceImplTest.java
+++ b/src/test/java/com/watermelon/server/randomevent/parts/service/LotteryApplierPartsServiceImplTest.java
@@ -3,6 +3,7 @@ package com.watermelon.server.randomevent.parts.service;
 import com.watermelon.server.randomevent.domain.LotteryApplier;
 import com.watermelon.server.randomevent.parts.domain.LotteryApplierParts;
 import com.watermelon.server.randomevent.parts.domain.Parts;
+import com.watermelon.server.randomevent.parts.domain.PartsCategory;
 import com.watermelon.server.randomevent.parts.repository.LotteryApplierPartsRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,8 +34,8 @@ class LotteryApplierPartsServiceImplTest {
     @DisplayName("만약 응모자가 가지고 있는 기존 파츠 중 신규 파츠가 카테고리의 첫 번째 파츠라면, 장착함.")
     void addPartsAndGetFirstPartsCase() {
 
-        final String CATEGORY2 = "2";
-        final String CATEGORY3 = "3";
+        final PartsCategory CATEGORY2 = PartsCategory.COLOR;
+        final PartsCategory CATEGORY3 = PartsCategory.WHEEL;
 
         //given (응모자가 가지고 있는 기존 파츠 중 신규 파츠가 카테고리의 첫 파츠일 때)
         final LotteryApplier lotteryApplier = LotteryApplier.builder()
@@ -73,12 +74,11 @@ class LotteryApplierPartsServiceImplTest {
     void addPartsAndGetNotFirstPartsCase() {
 
         //given
-        final String CATEGORY = "1";
 
         //when (응모자가 가지고 있는 기존 파츠 중 신규 파츠가 카테고리의 첫 파츠가 아닐 때)
         final LotteryApplier lotteryApplier = LotteryApplier.builder().id(anyLong()).build();
-        final Parts existParts = Parts.builder().category(CATEGORY).build();
-        final Parts newParts = Parts.builder().category(CATEGORY).build();
+        final Parts existParts = Parts.builder().category(PartsCategory.COLOR).build();
+        final Parts newParts = Parts.builder().category(PartsCategory.COLOR).build();
 
         final List<LotteryApplierParts> lotteryApplierPartsList = List.of(
                 LotteryApplierParts.createApplierParts(true, lotteryApplier, existParts)

--- a/src/test/java/com/watermelon/server/randomevent/parts/service/PartsServiceImplTest.java
+++ b/src/test/java/com/watermelon/server/randomevent/parts/service/PartsServiceImplTest.java
@@ -3,6 +3,7 @@ package com.watermelon.server.randomevent.parts.service;
 import com.watermelon.server.randomevent.domain.LotteryApplier;
 import com.watermelon.server.randomevent.parts.domain.LotteryApplierParts;
 import com.watermelon.server.randomevent.parts.domain.Parts;
+import com.watermelon.server.randomevent.parts.domain.PartsCategory;
 import com.watermelon.server.randomevent.parts.dto.response.ResponsePartsDrawDto;
 import com.watermelon.server.randomevent.parts.exception.PartsDrawLimitExceededException;
 import com.watermelon.server.randomevent.parts.repository.PartsRepository;
@@ -45,7 +46,9 @@ class PartsServiceImplTest {
                 .remainChance(1)
                 .build();
 
-        Parts parts = new Parts();
+        Parts parts = Parts.builder()
+                .category(PartsCategory.COLOR)
+                .build();
 
         when(lotteryService.applyAndGet(TEST_UID)).thenReturn(applier);
         when(partsRepository.findAll()).thenReturn(List.of(parts));


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-80

## 작업 내용
### feat
- [x] 파츠 목록 컨트롤러 구현 및 테스트
- [x] 파츠 목록 서비스 구현 및 테스트

### refactor
- [x] 파츠의 카테고리 필드 enum 타입으로 변경


