### PR TITLE
현재 진행중인 이벤트를 스케쥴링하여 바꾸도록 수정

### DIFF
--- a/src/main/java/com/watermelon/server/Scheduler.java
+++ b/src/main/java/com/watermelon/server/Scheduler.java
@@ -17,5 +17,7 @@ public class Scheduler {
     public void checkEventStart(){
         log.info("Checking events by scheduled");
         orderEventSchedulingService.changeOrderStatusByTime();
+        Long currentEventId = orderEventSchedulingService.changeCurrentOrderEvent();;
+        log.info("current order event id is {}", currentEventId);
     }
 }

--- a/src/main/java/com/watermelon/server/event/order/service/OrderEventCheckService.java
+++ b/src/main/java/com/watermelon/server/event/order/service/OrderEventCheckService.java
@@ -27,6 +27,9 @@ public class OrderEventCheckService {
         this.startDate = startDate;
         this.endDate = endDate;
     }
+    public Long getCurrentOrderEventId() {
+        return eventId;
+    }
 
     public void refreshOrderEventInProgress(OrderEvent orderEvent){
         this.eventId = orderEvent.getId();

--- a/src/main/java/com/watermelon/server/event/order/service/OrderEventCommandService.java
+++ b/src/main/java/com/watermelon/server/event/order/service/OrderEventCommandService.java
@@ -54,17 +54,18 @@ public class OrderEventCommandService {
     }
 
     @Transactional
-    public void findOrderEventToMakeInProgress(){
+    public Long findOrderEventToMakeInProgress(){
         //현재 OrderEvent의 상태를 주기적으로 변경
         List<OrderEvent> orderEvents = orderEventRepository.findAll();
-        if(orderEvents.isEmpty()) return; // 이벤트 없을시 스킵
+        if(orderEvents.isEmpty()) return null;// 이벤트 없을시 스킵
 
         for(OrderEvent orderEvent : orderEvents){
             //현재 이벤트중 시간에 맞는 이벤트가 있다면 현재 이벤트로 설정한다
             if(orderEvent.isTimeInEventTime(LocalDateTime.now())){
                 this.orderEventCheckService.refreshOrderEventInProgress(orderEvent);
+                return orderEvent.getId();
             }
         }
-
+        return null;
     }
 }

--- a/src/main/java/com/watermelon/server/event/order/service/OrderEventCommandService.java
+++ b/src/main/java/com/watermelon/server/event/order/service/OrderEventCommandService.java
@@ -57,7 +57,7 @@ public class OrderEventCommandService {
     public Long findOrderEventToMakeInProgress(){
         //현재 OrderEvent의 상태를 주기적으로 변경
         List<OrderEvent> orderEvents = orderEventRepository.findAll();
-        if(orderEvents.isEmpty()) return null;// 이벤트 없을시 스킵
+        if(orderEvents.isEmpty()) return orderEventCheckService.getCurrentOrderEventId();// 이벤트 없을시 스킵
 
         for(OrderEvent orderEvent : orderEvents){
             //현재 이벤트중 시간에 맞는 이벤트가 있다면 현재 이벤트로 설정한다
@@ -66,6 +66,6 @@ public class OrderEventCommandService {
                 return orderEvent.getId();
             }
         }
-        return null;
+        return orderEventCheckService.getCurrentOrderEventId();
     }
 }

--- a/src/main/java/com/watermelon/server/event/order/service/OrderEventCommandService.java
+++ b/src/main/java/com/watermelon/server/event/order/service/OrderEventCommandService.java
@@ -14,6 +14,7 @@ import com.watermelon.server.event.order.result.service.OrderResultCommandServic
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -55,9 +56,15 @@ public class OrderEventCommandService {
     @Transactional
     public void findOrderEventToMakeInProgress(){
         //현재 OrderEvent의 상태를 주기적으로 변경
-        List<OrderEvent> orderEvent = orderEventRepository.findAll();
-        if(orderEvent.isEmpty()) return; // 이벤트 없을시 스킵
-        OrderEvent currentOrderEvent = orderEvent.get(0); // 여기서 현재 이벤트를 검증해야함
-        this.orderEventCheckService.refreshOrderEventInProgress(currentOrderEvent);
+        List<OrderEvent> orderEvents = orderEventRepository.findAll();
+        if(orderEvents.isEmpty()) return; // 이벤트 없을시 스킵
+
+        for(OrderEvent orderEvent : orderEvents){
+            //현재 이벤트중 시간에 맞는 이벤트가 있다면 현재 이벤트로 설정한다
+            if(orderEvent.isTimeInEventTime(LocalDateTime.now())){
+                this.orderEventCheckService.refreshOrderEventInProgress(orderEvent);
+            }
+        }
+
     }
 }

--- a/src/main/java/com/watermelon/server/event/order/service/OrderEventSchedulingService.java
+++ b/src/main/java/com/watermelon/server/event/order/service/OrderEventSchedulingService.java
@@ -16,9 +16,14 @@ import java.util.List;
 public class OrderEventSchedulingService {
 
     private final OrderEventRepository orderEventRepository;
+    private final OrderEventCommandService orderEventCommandService;
     @Transactional
     public void changeOrderStatusByTime(){
         List<OrderEvent> orderEvents = orderEventRepository.findAll();
         orderEvents.forEach(orderEvent -> {orderEvent.changeOrderEventStatusByTime(LocalDateTime.now());});
+    }
+    @Transactional
+    public Long changeCurrentOrderEvent(){
+        return orderEventCommandService.findOrderEventToMakeInProgress();
     }
 }


### PR DESCRIPTION
## 연관된 이슈

https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-191

## 작업 내용
매분마다 현재 시간에 맞는 이벤트를 현재 이벤트로 설정


## 스크린샷 (선택)
<img width="690" alt="image" src="https://github.com/user-attachments/assets/025fe189-38c5-41d1-b9d5-7b0121b5bd3c">






