### PR TITLE
API 명세서 에러 경우 추가

### DIFF
--- a/src/main/java/com/watermelon/server/common/exception/ErrorResponse.java
+++ b/src/main/java/com/watermelon/server/common/exception/ErrorResponse.java
@@ -16,117 +16,129 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
-    private int status;                 // 에러 상태 코드
-    private String divisionCode;        // 에러 구분 코드
-    private String resultMsg;           // 에러 메시지
-    private List<FieldError> errors;    // 상세 에러 메시지
-    private String reason;              // 에러 이유
+    private String reason;
 
-    /**
-     * ErrorResponse 생성자-1
-     *
-     * @param code ErrorCode
-     */
-    @Builder
-    protected ErrorResponse(final ErrorCode code) {
-        this.resultMsg = code.getMessage();
-        this.status = code.getStatus();
-        this.divisionCode = code.getDivisionCode();
-        this.errors = new ArrayList<>();
+    public static ErrorResponse of(String reason){
+        return ErrorResponse.builder()
+                .reason(reason)
+                .build();
     }
-
-    /**
-     * ErrorResponse 생성자-2
-     *
-     * @param code   ErrorCode
-     * @param reason String
-     */
     @Builder
-    protected ErrorResponse(final ErrorCode code, final String reason) {
-        this.resultMsg = code.getMessage();
-        this.status = code.getStatus();
-        this.divisionCode = code.getDivisionCode();
+    public ErrorResponse(String reason) {
         this.reason = reason;
     }
 
-    /**
-     * ErrorResponse 생성자-3
-     *
-     * @param code   ErrorCode
-     * @param errors List<FieldError>
-     */
-    @Builder
-    protected ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
-        this.resultMsg = code.getMessage();
-        this.status = code.getStatus();
-        this.errors = errors;
-        this.divisionCode = code.getDivisionCode();
-    }
-
-
-    /**
-     * Global Exception 전송 타입-1
-     *
-     * @param code          ErrorCode
-     * @param bindingResult BindingResult
-     * @return ErrorResponse
-     */
-    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
-        return new ErrorResponse(code, FieldError.of(bindingResult));
-    }
-
-    /**
-     * Global Exception 전송 타입-2
-     *
-     * @param code ErrorCode
-     * @return ErrorResponse
-     */
-    public static ErrorResponse of(final ErrorCode code) {
-        return new ErrorResponse(code);
-    }
-
-    /**
-     * Global Exception 전송 타입-3
-     *
-     * @param code   ErrorCode
-     * @param reason String
-     * @return ErrorResponse
-     */
-    public static ErrorResponse of(final ErrorCode code, final String reason) {
-        return new ErrorResponse(code, reason);
-    }
-
-
-    /**
-     * 에러를 e.getBindingResult() 형태로 전달 받는 경우 해당 내용을 상세 내용으로 변경하는 기능을 수행한다.
-     */
-    @Getter
-    public static class FieldError {
-        private final String field;
-        private final String value;
-        private final String reason;
-
-        public static List<FieldError> of(final String field, final String value, final String reason) {
-            List<FieldError> fieldErrors = new ArrayList<>();
-            fieldErrors.add(new FieldError(field, value, reason));
-            return fieldErrors;
-        }
-
-        private static List<FieldError> of(final BindingResult bindingResult) {
-            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
-            return fieldErrors.stream()
-                    .map(error -> new FieldError(
-                            error.getField(),
-                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
-                            error.getDefaultMessage()))
-                    .collect(Collectors.toList());
-        }
-
-        @Builder
-        FieldError(String field, String value, String reason) {
-            this.field = field;
-            this.value = value;
-            this.reason = reason;
-        }
-    }
+    //    private int status;                 // 에러 상태 코드
+//    private String divisionCode;        // 에러 구분 코드
+//    private String resultMsg;           // 에러 메시지
+//    private List<FieldError> errors;    // 상세 에러 메시지
+//    private String reason;              // 에러 이유
+//
+//    /**
+//     * ErrorResponse 생성자-1
+//     *
+//     * @param code ErrorCode
+//     */
+//    @Builder
+//    protected ErrorResponse(final ErrorCode code) {
+//        this.resultMsg = code.getMessage();
+//        this.status = code.getStatus();
+//        this.divisionCode = code.getDivisionCode();
+//        this.errors = new ArrayList<>();
+//    }
+//
+//    /**
+//     * ErrorResponse 생성자-2
+//     *
+//     * @param code   ErrorCode
+//     * @param reason String
+//     */
+//    @Builder
+//    protected ErrorResponse(final ErrorCode code, final String reason) {
+//        this.resultMsg = code.getMessage();
+//        this.status = code.getStatus();
+//        this.divisionCode = code.getDivisionCode();
+//        this.reason = reason;
+//    }
+//
+//    /**
+//     * ErrorResponse 생성자-3
+//     *
+//     * @param code   ErrorCode
+//     * @param errors List<FieldError>
+//     */
+//    @Builder
+//    protected ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+//        this.resultMsg = code.getMessage();
+//        this.status = code.getStatus();
+//        this.errors = errors;
+//        this.divisionCode = code.getDivisionCode();
+//    }
+//
+//
+//    /**
+//     * Global Exception 전송 타입-1
+//     *
+//     * @param code          ErrorCode
+//     * @param bindingResult BindingResult
+//     * @return ErrorResponse
+//     */
+//    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+//        return new ErrorResponse(code, FieldError.of(bindingResult));
+//    }
+//
+//    /**
+//     * Global Exception 전송 타입-2
+//     *
+//     * @param code ErrorCode
+//     * @return ErrorResponse
+//     */
+//    public static ErrorResponse of(final ErrorCode code) {
+//        return new ErrorResponse(code);
+//    }
+//
+//    /**
+//     * Global Exception 전송 타입-3
+//     *
+//     * @param code   ErrorCode
+//     * @param reason String
+//     * @return ErrorResponse
+//     */
+//    public static ErrorResponse of(final ErrorCode code, final String reason) {
+//        return new ErrorResponse(code, reason);
+//    }
+//
+//
+//    /**
+//     * 에러를 e.getBindingResult() 형태로 전달 받는 경우 해당 내용을 상세 내용으로 변경하는 기능을 수행한다.
+//     */
+//    @Getter
+//    public static class FieldError {
+//        private final String field;
+//        private final String value;
+//        private final String reason;
+//
+//        public static List<FieldError> of(final String field, final String value, final String reason) {
+//            List<FieldError> fieldErrors = new ArrayList<>();
+//            fieldErrors.add(new FieldError(field, value, reason));
+//            return fieldErrors;
+//        }
+//
+//        private static List<FieldError> of(final BindingResult bindingResult) {
+//            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+//            return fieldErrors.stream()
+//                    .map(error -> new FieldError(
+//                            error.getField(),
+//                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+//                            error.getDefaultMessage()))
+//                    .collect(Collectors.toList());
+//        }
+//
+//        @Builder
+//        FieldError(String field, String value, String reason) {
+//            this.field = field;
+//            this.value = value;
+//            this.reason = reason;
+//        }
+//    }
 }

--- a/src/main/java/com/watermelon/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/watermelon/server/common/exception/GlobalExceptionHandler.java
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
             stringBuilder.append(fieldError.getDefaultMessage());
             stringBuilder.append(", ");
         }
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.NOT_VALID_ERROR, String.valueOf(stringBuilder));
+        final ErrorResponse response = ErrorResponse.of( String.valueOf(stringBuilder));
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 
@@ -55,7 +55,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingRequestHeaderException.class)
     protected ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
         log.error("MissingRequestHeaderException", ex);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.REQUEST_BODY_MISSING_ERROR, ex.getMessage());
+        final ErrorResponse response = ErrorResponse.of(ex.getMessage());
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 
@@ -69,7 +69,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
             HttpMessageNotReadableException ex) {
         log.error("HttpMessageNotReadableException", ex);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.REQUEST_BODY_MISSING_ERROR, ex.getMessage());
+        final ErrorResponse response = ErrorResponse.of( ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
@@ -83,7 +83,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleMissingRequestHeaderExceptionException(
             MissingServletRequestParameterException ex) {
         log.error("handleMissingServletRequestParameterException", ex);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.MISSING_REQUEST_PARAMETER_ERROR, ex.getMessage());
+        final ErrorResponse response = ErrorResponse.of( ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
@@ -96,7 +96,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpClientErrorException.BadRequest.class)
     protected ResponseEntity<ErrorResponse> handleBadRequestException(HttpClientErrorException e) {
         log.error("HttpClientErrorException.BadRequest", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.BAD_REQUEST_ERROR, e.getMessage());
+        final ErrorResponse response = ErrorResponse.of( e.getMessage());
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 
@@ -110,7 +110,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoHandlerFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNoHandlerFoundExceptionException(NoHandlerFoundException e) {
         log.error("handleNoHandlerFoundExceptionException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.NOT_FOUND_ERROR, e.getMessage());
+        final ErrorResponse response = ErrorResponse.of(e.getMessage());
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 
@@ -124,7 +124,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NullPointerException.class)
     protected ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
         log.error("handleNullPointerException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.NULL_POINT_ERROR, e.getMessage());
+        final ErrorResponse response = ErrorResponse.of( e.getMessage());
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 
@@ -137,7 +137,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IOException.class)
     protected ResponseEntity<ErrorResponse> handleIOException(IOException ex) {
         log.error("handleIOException", ex);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.IO_ERROR, ex.getMessage());
+        final ErrorResponse response = ErrorResponse.of( ex.getMessage());
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 
@@ -150,7 +150,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     protected final ResponseEntity<ErrorResponse> handleAllExceptions(Exception ex) {
         log.error("Exception", ex);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, ex.getMessage());
+        final ErrorResponse response = ErrorResponse.of(ex.getMessage());
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 }

--- a/src/main/java/com/watermelon/server/error/ApplyTicketWrongException.java
+++ b/src/main/java/com/watermelon/server/error/ApplyTicketWrongException.java
@@ -4,6 +4,6 @@ package com.watermelon.server.error;
 
 public class ApplyTicketWrongException extends Exception{
     public ApplyTicketWrongException(){
-        super("유효하지 않은 티켓");
+        super("apply ticket not verified");
     }
 }

--- a/src/main/java/com/watermelon/server/event/lottery/controller/ExpectationController.java
+++ b/src/main/java/com/watermelon/server/event/lottery/controller/ExpectationController.java
@@ -1,17 +1,16 @@
 package com.watermelon.server.event.lottery.controller;
 
+import com.watermelon.server.common.exception.ErrorResponse;
 import com.watermelon.server.event.lottery.auth.annotations.Uid;
 import com.watermelon.server.event.lottery.dto.request.RequestExpectationDto;
 import com.watermelon.server.event.lottery.dto.response.ResponseExpectationDto;
 import com.watermelon.server.event.lottery.error.ExpectationAlreadyExistError;
 import com.watermelon.server.event.lottery.service.ExpectationService;
+import com.watermelon.server.event.order.error.NotDuringEventPeriodException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -34,6 +33,11 @@ public class ExpectationController {
     @GetMapping(path ="/expectations")
     public ResponseEntity<List<ResponseExpectationDto>> getExpectationsForUser() {
         return new ResponseEntity<>(expectationService.getExpectationsForUser(),HttpStatus.OK);
+    }
+
+    @ExceptionHandler(ExpectationAlreadyExistError.class)
+    public ResponseEntity<ErrorResponse> handleNotDuringEventPeriodException(NotDuringEventPeriodException notDuringEventPeriodException){
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of(notDuringEventPeriodException.getMessage()));
     }
 
 }

--- a/src/main/java/com/watermelon/server/event/lottery/controller/ExpectationController.java
+++ b/src/main/java/com/watermelon/server/event/lottery/controller/ExpectationController.java
@@ -36,8 +36,8 @@ public class ExpectationController {
     }
 
     @ExceptionHandler(ExpectationAlreadyExistError.class)
-    public ResponseEntity<ErrorResponse> handleNotDuringEventPeriodException(NotDuringEventPeriodException notDuringEventPeriodException){
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of(notDuringEventPeriodException.getMessage()));
+    public ResponseEntity<ErrorResponse> handleNotDuringEventPeriodException(ExpectationAlreadyExistError expectationAlreadyExistError){
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of(expectationAlreadyExistError.getMessage()));
     }
 
 }

--- a/src/main/java/com/watermelon/server/event/lottery/error/ExpectationAlreadyExistError.java
+++ b/src/main/java/com/watermelon/server/event/lottery/error/ExpectationAlreadyExistError.java
@@ -1,4 +1,7 @@
 package com.watermelon.server.event.lottery.error;
 
 public class ExpectationAlreadyExistError extends Exception{
+    public ExpectationAlreadyExistError() {
+        super("expectation_already_exist");
+    }
 }

--- a/src/main/java/com/watermelon/server/event/lottery/parts/controller/PartsController.java
+++ b/src/main/java/com/watermelon/server/event/lottery/parts/controller/PartsController.java
@@ -1,11 +1,13 @@
 package com.watermelon.server.event.lottery.parts.controller;
 
+import com.watermelon.server.common.exception.ErrorResponse;
 import com.watermelon.server.event.lottery.auth.annotations.Uid;
 import com.watermelon.server.event.lottery.parts.dto.response.ResponseMyPartsListDto;
 import com.watermelon.server.event.lottery.parts.dto.response.ResponsePartsDrawDto;
 import com.watermelon.server.event.lottery.parts.dto.response.ResponseRemainChanceDto;
 import com.watermelon.server.event.lottery.parts.exception.PartsDrawLimitExceededException;
 import com.watermelon.server.event.lottery.parts.service.PartsService;
+import com.watermelon.server.event.order.error.NotDuringEventPeriodException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,12 +29,8 @@ public class PartsController {
     @PostMapping
     public ResponseEntity<ResponsePartsDrawDto> drawParts(
             @Uid String uid
-    ){
-        try {
-            return new ResponseEntity<>(partsService.drawParts(uid), HttpStatus.OK);
-        }catch (PartsDrawLimitExceededException e){
-            return new ResponseEntity<>(HttpStatus.TOO_MANY_REQUESTS);
-        }
+    ) throws PartsDrawLimitExceededException {
+        return new ResponseEntity<>(partsService.drawParts(uid), HttpStatus.OK);
     }
 
     @PatchMapping("/{partsId}")
@@ -64,5 +62,10 @@ public class PartsController {
     ){
         return new ResponseEntity<>(partsService.getPartsList(link_key), HttpStatus.OK);
     }
+    @ExceptionHandler(PartsDrawLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handlePartsDrawLimitExceedException(PartsDrawLimitExceededException partsDrawLimitExceededException){
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ErrorResponse.of(partsDrawLimitExceededException.getMessage()));
+    }
+
 
 }

--- a/src/main/java/com/watermelon/server/event/lottery/parts/exception/PartsDrawLimitExceededException.java
+++ b/src/main/java/com/watermelon/server/event/lottery/parts/exception/PartsDrawLimitExceededException.java
@@ -1,4 +1,7 @@
 package com.watermelon.server.event.lottery.parts.exception;
 
 public class PartsDrawLimitExceededException extends RuntimeException {
+    public PartsDrawLimitExceededException() {
+        super("Part draw limit exceeded");
+    }
 }

--- a/src/main/java/com/watermelon/server/event/order/controller/OrderEventController.java
+++ b/src/main/java/com/watermelon/server/event/order/controller/OrderEventController.java
@@ -63,7 +63,7 @@ public class OrderEventController {
     }
 
     @ExceptionHandler(WrongPhoneNumberFormatException.class)
-    public ResponseEntity<ErrorResponse> handlePhoneNumberNotExistException(WrongPhoneNumberFormatException wrongPhoneNumberFormatException){
+    public ResponseEntity<ErrorResponse> handleWrongPhoneNumberFormatException(WrongPhoneNumberFormatException wrongPhoneNumberFormatException){
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ErrorResponse.of(wrongPhoneNumberFormatException.getMessage()));
     }
     @ExceptionHandler(WrongOrderEventFormatException.class)

--- a/src/main/java/com/watermelon/server/event/order/controller/OrderEventController.java
+++ b/src/main/java/com/watermelon/server/event/order/controller/OrderEventController.java
@@ -1,6 +1,7 @@
 package com.watermelon.server.event.order.controller;
 
 
+import com.watermelon.server.common.exception.ErrorResponse;
 import com.watermelon.server.error.ApplyTicketWrongException;
 import com.watermelon.server.event.order.dto.request.OrderEventWinnerRequestDto;
 import com.watermelon.server.event.order.dto.request.RequestAnswerDto;
@@ -62,20 +63,20 @@ public class OrderEventController {
     }
 
     @ExceptionHandler(WrongPhoneNumberFormatException.class)
-    public ResponseEntity<String> handlePhoneNumberNotExistException(WrongPhoneNumberFormatException wrongPhoneNumberFormatException){
-        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(wrongPhoneNumberFormatException.getMessage());
+    public ResponseEntity<ErrorResponse> handlePhoneNumberNotExistException(WrongPhoneNumberFormatException wrongPhoneNumberFormatException){
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ErrorResponse.of(wrongPhoneNumberFormatException.getMessage()));
     }
     @ExceptionHandler(WrongOrderEventFormatException.class)
-    public ResponseEntity<String> handleWrongOrderEventFormatException(WrongOrderEventFormatException wrongOrderEventFormatException){
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(wrongOrderEventFormatException.getMessage());
+    public ResponseEntity<ErrorResponse> handleWrongOrderEventFormatException(WrongOrderEventFormatException wrongOrderEventFormatException){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(wrongOrderEventFormatException.getMessage()));
     }
     @ExceptionHandler(ApplyTicketWrongException.class)
-    public ResponseEntity<String> handleApplyTicketWrongException(ApplyTicketWrongException applyTicketWrongException){
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(applyTicketWrongException.getMessage());
+    public ResponseEntity<ErrorResponse> handleApplyTicketWrongException(ApplyTicketWrongException applyTicketWrongException){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.of(applyTicketWrongException.getMessage()));
     }
     @ExceptionHandler(NotDuringEventPeriodException.class)
-    public ResponseEntity<String> handleNotDuringEventPeriodException(NotDuringEventPeriodException notDuringEventPeriodException){
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(notDuringEventPeriodException.getMessage());
+    public ResponseEntity<ErrorResponse> handleNotDuringEventPeriodException(NotDuringEventPeriodException notDuringEventPeriodException){
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(notDuringEventPeriodException.getMessage()));
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   profiles:
     active: ${name:local}
+server:
+  port: 8082

--- a/src/test/java/com/watermelon/server/admin/controller/AdminExpectationControllerTest.java
+++ b/src/test/java/com/watermelon/server/admin/controller/AdminExpectationControllerTest.java
@@ -59,7 +59,7 @@ class AdminExpectationControllerTest extends ControllerTest {
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag(TAG_EXPECTATION)
-                                        .description("기대평 목록 조회")
+                                        .description("어드민 기대평 목록 조회")
                                         .build()
                         )));
     }

--- a/src/test/java/com/watermelon/server/admin/controller/AdminOrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/admin/controller/AdminOrderEventControllerTest.java
@@ -205,6 +205,6 @@ class AdminOrderEventControllerTest extends ControllerTest {
     }
 
     @Test
-    void handlePhoneNumberNotExistException() {
+    void handleWrongPhoneNumberFormatException() {
     }
 }

--- a/src/test/java/com/watermelon/server/event/lottery/controller/ExpectationControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/lottery/controller/ExpectationControllerTest.java
@@ -64,7 +64,7 @@ class ExpectationControllerTest extends ControllerTest {
     @DisplayName("[DOC] 사용자 기대평을 만든다")
     void makeExpectationMakeConflictError() throws Exception {
         final String PATH = "/expectations";
-        final String DOCUMENT_NAME ="expectations/create/conflict";
+        final String DOCUMENT_NAME ="expectation-conflict";
         Mockito.doThrow(ExpectationAlreadyExistError.class).when(expectationService).makeExpectation(any(),any());
 
         mvc.perform(

--- a/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
@@ -222,6 +222,29 @@ class OrderEventControllerTest extends ControllerTest {
                         )));
     }
     @Test
+    @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 - 선착순 마감")
+    void makeApplyClosed() throws Exception {
+        final String Path = "/event/order/{eventId}/{quizId}";
+        final String DOCUMENT_NAME ="full-apply";
+        String applyTicket = "applyTicket";
+        Mockito.when(orderEventCommandService.makeApplyTicket(any(),any(),any())).thenReturn(ResponseApplyTicketDto.fullApply());
+        mvc.perform(RestDocumentationRequestBuilders.post(Path,
+                                openOrderEventResponse.getEventId(),
+                                openOrderEventResponse.getQuiz().getQuizId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(RequestAnswerDto.makeWith("answer")))
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_ORDER)
+                                        .description("선착순 퀴즈 정답 제출")
+                                        .build()
+                        )));
+    }
+    @Test
     @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 - 정답 틀림")
     void makeApplyWrongAnswer() throws Exception {
         final String Path = "/event/order/{eventId}/{quizId}";

--- a/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
@@ -8,6 +8,7 @@ import com.watermelon.server.event.order.domain.OrderEventStatus;
 import com.watermelon.server.event.order.dto.request.*;
 import com.watermelon.server.event.order.dto.response.ResponseApplyTicketDto;
 import com.watermelon.server.event.order.dto.response.ResponseOrderEventDto;
+import com.watermelon.server.event.order.error.WrongOrderEventFormatException;
 import com.watermelon.server.event.order.repository.OrderEventRepository;
 import com.watermelon.server.event.order.service.OrderEventCommandService;
 import com.watermelon.server.event.order.service.OrderEventQueryService;
@@ -112,12 +113,29 @@ class OrderEventControllerTest extends ControllerTest {
     void getOrderEvent() throws Exception {
         final String PATH = "/event/order/{eventId}";
         final String DOCUMENT_NAME ="event/order/{eventId}";
-        System.out.println(openOrderEventResponse);
         Mockito.when(orderEventQueryService.getOrderEvent(openOrderEventResponse.getEventId())).thenReturn(openOrderEventResponse);
 
         mvc.perform(RestDocumentationRequestBuilders.get(PATH, openOrderEventResponse.getEventId()))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(openOrderEventResponse)))
+                .andDo(print())
+                .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_ORDER)
+                                        .description("특정 선착순 이벤트 조회")
+                                        .build()
+                        )));
+    }
+
+    @Test
+    @DisplayName("[DOC] 존재하지 않는 선착순 이벤트를 가져온다")
+    void getOrderEventNotExist() throws Exception {
+        final String PATH = "/event/order/{eventId}";
+        final String DOCUMENT_NAME ="event/order/{eventId}/not-exist";
+        Mockito.when(orderEventQueryService.getOrderEvent(openOrderEventResponse.getEventId())).thenThrow(WrongOrderEventFormatException.class);
+        mvc.perform(RestDocumentationRequestBuilders.get(PATH, openOrderEventResponse.getEventId()))
+                .andExpect(status().isNotFound())
                 .andDo(print())
                 .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
                         resource(

--- a/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
@@ -91,10 +91,10 @@ class OrderEventControllerTest extends ControllerTest {
 
     }
     @Test
-    @DisplayName("[DOC] 선착순 이벤트 목록을 가져온다")
+    @DisplayName("[DOC] 선착순 이벤트 목록을 가져온다 - 성공")
     void getOrderEvents() throws Exception {
         final String PATH = "/event/order";
-        final String DOCUMENT_NAME ="event/order";
+        final String DOCUMENT_NAME ="success";
         Mockito.when(orderEventQueryService.getOrderEvents()).thenReturn(responseOrderEventDtos);
 
         mvc.perform(RestDocumentationRequestBuilders.get(PATH))
@@ -110,10 +110,10 @@ class OrderEventControllerTest extends ControllerTest {
                         )));
     }
     @Test
-    @DisplayName("[DOC] 특정 선착순 이벤트를 가져온다")
+    @DisplayName("[DOC] 특정 선착순 이벤트를 가져온다 - 성공")
     void getOrderEvent() throws Exception {
         final String PATH = "/event/order/{eventId}";
-        final String DOCUMENT_NAME ="event/order/{eventId}";
+        final String DOCUMENT_NAME ="success}";
         Mockito.when(orderEventQueryService.getOrderEvent(openOrderEventResponse.getEventId())).thenReturn(openOrderEventResponse);
 
         mvc.perform(RestDocumentationRequestBuilders.get(PATH, openOrderEventResponse.getEventId()))
@@ -133,7 +133,7 @@ class OrderEventControllerTest extends ControllerTest {
     @DisplayName("[DOC] 존재하지 않는 선착순 이벤트를 가져온다")
     void getOrderEventNotExist() throws Exception {
         final String PATH = "/event/order/{eventId}";
-        final String DOCUMENT_NAME ="event/order/{eventId}/not-exist";
+        final String DOCUMENT_NAME ="event-not-exist";
         Mockito.when(orderEventQueryService.getOrderEvent(openOrderEventResponse.getEventId())).thenThrow(WrongOrderEventFormatException.class);
         mvc.perform(RestDocumentationRequestBuilders.get(PATH, openOrderEventResponse.getEventId()))
                 .andExpect(status().isNotFound())
@@ -148,10 +148,10 @@ class OrderEventControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("[DOC] 선착순 이벤트 번호 제출")
+    @DisplayName("[DOC] 선착순 이벤트 번호 제출 - 성공 ")
     void makeApplyTicket() throws Exception {
         final String Path = "/event/order/{eventId}/{quizId}/apply";
-        final String DOCUMENT_NAME ="event/order/{eventId}/{quizId}/apply";
+        final String DOCUMENT_NAME ="success";
 
 
         String applyTicket = "applyTicket";
@@ -198,10 +198,10 @@ class OrderEventControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출")
+    @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 - 성공")
     void makeApply() throws Exception {
         final String Path = "/event/order/{eventId}/{quizId}";
-        final String DOCUMENT_NAME ="event/order/{eventId}/{quizId}";
+        final String DOCUMENT_NAME ="success";
         String applyTicket = "applyTicket";
         Mockito.when(orderEventCommandService.makeApplyTicket(any(),any(),any())).thenReturn(ResponseApplyTicketDto.applySuccess(applyTicket));
         mvc.perform(RestDocumentationRequestBuilders.post(Path,
@@ -222,10 +222,33 @@ class OrderEventControllerTest extends ControllerTest {
                         )));
     }
     @Test
+    @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 - 정답 틀림")
+    void makeApplyWrongAnswer() throws Exception {
+        final String Path = "/event/order/{eventId}/{quizId}";
+        final String DOCUMENT_NAME ="wrong-answer";
+        String applyTicket = "applyTicket";
+        Mockito.when(orderEventCommandService.makeApplyTicket(any(),any(),any())).thenReturn(ResponseApplyTicketDto.wrongAnswer());
+        mvc.perform(RestDocumentationRequestBuilders.post(Path,
+                                openOrderEventResponse.getEventId(),
+                                openOrderEventResponse.getQuiz().getQuizId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(RequestAnswerDto.makeWith("answer")))
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_ORDER)
+                                        .description("선착순 퀴즈 정답 제출")
+                                        .build()
+                        )));
+    }
+    @Test
     @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 -에러(기간이 틀림)")
     void makeApplyNotDuringDuration() throws Exception {
         final String Path = "/event/order/{eventId}/{quizId}";
-        final String DOCUMENT_NAME ="event/order/{eventId}/{quizId}/not-during-duration";
+        final String DOCUMENT_NAME ="not-during-duration";
         String applyTicket = "applyTicket";
         Mockito.when(orderEventCommandService.makeApplyTicket(any(),any(),any())).thenThrow(NotDuringEventPeriodException.class);
         mvc.perform(RestDocumentationRequestBuilders.post(Path,
@@ -245,10 +268,10 @@ class OrderEventControllerTest extends ControllerTest {
                         )));
     }
     @Test
-    @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 -에러(기간이 틀림)")
+    @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 -에러(현재 진행중인 이벤트 아님)")
     void makeApplyWrongCurrentEvent() throws Exception {
         final String Path = "/event/order/{eventId}/{quizId}";
-        final String DOCUMENT_NAME ="event/order/{eventId}/{quizId}/wrong-current-event";
+        final String DOCUMENT_NAME ="wrong-current-event";
         String applyTicket = "applyTicket";
         Mockito.when(orderEventCommandService.makeApplyTicket(any(),any(),any())).thenThrow(WrongOrderEventFormatException.class);
         mvc.perform(RestDocumentationRequestBuilders.post(Path,

--- a/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
@@ -249,6 +249,32 @@ class OrderEventControllerTest extends ControllerTest {
                         )));
 
     }
+    @Test
+    @DisplayName("[DOC] 선착순 이벤트 번호 제출 - 에러(존재하지 않는 이벤트)")
+    void makeApplyTicketWrongOrderEvent() throws Exception {
+        final String Path = "/event/order/{eventId}/{quizId}/apply";
+        final String DOCUMENT_NAME = "phone-number-wrong-format";
+        String applyTicket = "applyTicket";
+        Mockito.doThrow(WrongOrderEventFormatException.class).when(orderEventCommandService).makeOrderEventWinner(any(),any(),any());
+
+
+        mvc.perform(RestDocumentationRequestBuilders.post(Path,
+                                openOrderEventResponse.getEventId(),
+                                openOrderEventResponse.getQuiz().getQuizId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(OrderEventWinnerRequestDto.makeWithPhoneNumber("01012341234")))
+                        .header("ApplyTicket", applyTicket))
+                .andExpect(status().isNotFound())
+                .andDo(print())
+                .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_ORDER)
+                                        .description("선착순 퀴즈 번호 제출")
+                                        .build()
+                        )));
+
+    }
         @Test
     @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 - 성공")
     void makeApply() throws Exception {

--- a/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
@@ -11,6 +11,7 @@ import com.watermelon.server.event.order.dto.response.ResponseApplyTicketDto;
 import com.watermelon.server.event.order.dto.response.ResponseOrderEventDto;
 import com.watermelon.server.event.order.error.NotDuringEventPeriodException;
 import com.watermelon.server.event.order.error.WrongOrderEventFormatException;
+import com.watermelon.server.event.order.error.WrongPhoneNumberFormatException;
 import com.watermelon.server.event.order.repository.OrderEventRepository;
 import com.watermelon.server.event.order.service.OrderEventCommandService;
 import com.watermelon.server.event.order.service.OrderEventQueryService;
@@ -213,6 +214,31 @@ class OrderEventControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(OrderEventWinnerRequestDto.makeWithPhoneNumber("01012341234")))
                         .header("ApplyTicket", applyTicket))
                 .andExpect(status().isUnauthorized())
+                .andDo(print())
+                .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_ORDER)
+                                        .description("선착순 퀴즈 번호 제출")
+                                        .build()
+                        )));
+    }
+    @Test
+    @DisplayName("[DOC] 선착순 이벤트 번호 제출 - 에러(phone number 형식 맞지 안흥ㅁ)")
+    void makeApplyTicketWrongPhoneNumberFormat() throws Exception {
+        final String Path = "/event/order/{eventId}/{quizId}/apply";
+        final String DOCUMENT_NAME = "phone-number-wrong-format";
+        String applyTicket = "applyTicket";
+        Mockito.doThrow(WrongPhoneNumberFormatException.class).when(orderEventCommandService).makeOrderEventWinner(any(),any(),any());
+
+
+        mvc.perform(RestDocumentationRequestBuilders.post(Path,
+                                openOrderEventResponse.getEventId(),
+                                openOrderEventResponse.getQuiz().getQuizId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(OrderEventWinnerRequestDto.makeWithPhoneNumber("01012341234")))
+                        .header("ApplyTicket", applyTicket))
+                .andExpect(status().isUnprocessableEntity())
                 .andDo(print())
                 .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
                         resource(

--- a/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
@@ -249,6 +249,7 @@ class OrderEventControllerTest extends ControllerTest {
                         )));
 
     }
+
     @Test
     @DisplayName("[DOC] 선착순 이벤트 번호 제출 - 에러(존재하지 않는 이벤트)")
     void makeApplyTicketWrongOrderEvent() throws Exception {
@@ -256,7 +257,6 @@ class OrderEventControllerTest extends ControllerTest {
         final String DOCUMENT_NAME = "phone-number-wrong-format";
         String applyTicket = "applyTicket";
         Mockito.doThrow(WrongOrderEventFormatException.class).when(orderEventCommandService).makeOrderEventWinner(any(),any(),any());
-
 
         mvc.perform(RestDocumentationRequestBuilders.post(Path,
                                 openOrderEventResponse.getEventId(),

--- a/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/order/controller/OrderEventControllerTest.java
@@ -244,4 +244,27 @@ class OrderEventControllerTest extends ControllerTest {
                                         .build()
                         )));
     }
+    @Test
+    @DisplayName("[DOC] 선착순 이벤트 퀴즈 정답 제출 -에러(기간이 틀림)")
+    void makeApplyWrongCurrentEvent() throws Exception {
+        final String Path = "/event/order/{eventId}/{quizId}";
+        final String DOCUMENT_NAME ="event/order/{eventId}/{quizId}/wrong-current-event";
+        String applyTicket = "applyTicket";
+        Mockito.when(orderEventCommandService.makeApplyTicket(any(),any(),any())).thenThrow(WrongOrderEventFormatException.class);
+        mvc.perform(RestDocumentationRequestBuilders.post(Path,
+                                openOrderEventResponse.getEventId(),
+                                openOrderEventResponse.getQuiz().getQuizId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(RequestAnswerDto.makeWith("answer")))
+                )
+                .andExpect(status().isNotFound())
+                .andDo(print())
+                .andDo(MockMvcRestDocumentationWrapper.document(DOCUMENT_NAME,
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_ORDER)
+                                        .description("선착순 퀴즈 정답 제출")
+                                        .build()
+                        )));
+    }
 }


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-195
## 작업 내용
- 에러 경우와 성공 실패 경우를 나누어서 API 명세서에 출력
- ErrorResponse 통일
## 스크린샷 (선택)
<img width="808" alt="image" src="https://github.com/user-attachments/assets/50f21100-f8a9-4cea-92bd-9aca09a07f3d">





