### PR TITLE
링크 API 수정

### DIFF
--- a/src/main/java/com/watermelon/server/event/link/controller/LinkController.java
+++ b/src/main/java/com/watermelon/server/event/link/controller/LinkController.java
@@ -32,7 +32,7 @@ public class LinkController {
         HttpHeaders headers = new HttpHeaders();
 
         // 현재 서버의 URL을 기반으로 새로운 경로를 생성
-        headers.add(HttpHeaders.LOCATION, LinkUtils.makeUrl(linkService.getUrl(shortedUri)));
+        headers.add(HttpHeaders.LOCATION, linkService.getRedirectUrl(shortedUri));
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 

--- a/src/main/java/com/watermelon/server/event/link/controller/LinkController.java
+++ b/src/main/java/com/watermelon/server/event/link/controller/LinkController.java
@@ -22,7 +22,7 @@ public class LinkController {
     public ResponseEntity<MyLinkDto> getMyLink(
             @Uid String uid
     ){
-        return new ResponseEntity<>(linkService.getMyLink(uid), HttpStatus.OK);
+        return new ResponseEntity<>(linkService.getShortedLink(uid), HttpStatus.OK);
     }
 
     @GetMapping("/link/{shortedUri}")

--- a/src/main/java/com/watermelon/server/event/link/service/LinkService.java
+++ b/src/main/java/com/watermelon/server/event/link/service/LinkService.java
@@ -26,4 +26,6 @@ public interface LinkService {
      * @return 원래 uri
      */
     String getUrl(String shortedUri);
+
+    String getRedirectUrl(String shortedUri);
 }

--- a/src/main/java/com/watermelon/server/event/link/service/LinkService.java
+++ b/src/main/java/com/watermelon/server/event/link/service/LinkService.java
@@ -10,7 +10,7 @@ public interface LinkService {
      * @param uid 응모자의 uid
      * @return 링크 정보
      */
-    MyLinkDto getMyLink(String uid);
+    MyLinkDto getShortedLink(String uid);
 
     /**
      * 링크 키에 대한 뷰 카운트를 증가시킨다.

--- a/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
+++ b/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
@@ -19,6 +19,9 @@ public class LinkServiceImpl implements LinkService {
     private final LotteryService lotteryService;
     private final LinkRepository linkRepository;
 
+    @Value("${server.parts-share-url}")
+    private String partsShareUrl;
+
     @Value("${server.base-url}")
     private String baseUrl;
 
@@ -52,6 +55,11 @@ public class LinkServiceImpl implements LinkService {
     @Override
     public String getUrl(String shortedUri) {
         return LinkUtils.fromBase62(shortedUri);
+    }
+
+    @Override
+    public String getRedirectUrl(String shortedUri) {
+        return partsShareUrl+"/"+getUrl(shortedUri);
     }
 
     private Link findLink(String uri) {

--- a/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
+++ b/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
@@ -9,23 +9,29 @@ import com.watermelon.server.event.link.utils.LinkUtils;
 import com.watermelon.server.event.lottery.service.LotteryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class LinkServiceImpl implements LinkService{
+public class LinkServiceImpl implements LinkService {
 
     private final LotteryService lotteryService;
     private final LinkRepository linkRepository;
 
+    @Value("${server.base-url}")
+    private String baseUrl;
+
     @Transactional
     @Override
     public MyLinkDto getShortedLink(String uid) {
-        LotteryApplier lotteryApplier =  lotteryService.findLotteryApplierByUid(uid);
-        return MyLinkDto.create(
-                lotteryApplier
+        LotteryApplier lotteryApplier = lotteryService.findLotteryApplierByUid(uid);
+        String shortedLink = baseUrl+"/link/"+LinkUtils
+                .toBase62(lotteryApplier
                         .getLink()
-                        .getUri()
+                        .getUri());
+        return MyLinkDto.create(
+            shortedLink
         );
     }
 
@@ -48,7 +54,7 @@ public class LinkServiceImpl implements LinkService{
         return LinkUtils.fromBase62(shortedUri);
     }
 
-    private Link findLink(String uri){
+    private Link findLink(String uri) {
         return linkRepository.findByUri(uri).orElseThrow(LinkNotFoundException::new);
     }
 

--- a/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
+++ b/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
@@ -20,7 +20,7 @@ public class LinkServiceImpl implements LinkService{
 
     @Transactional
     @Override
-    public MyLinkDto getMyLink(String uid) {
+    public MyLinkDto getShortedLink(String uid) {
         LotteryApplier lotteryApplier =  lotteryService.findLotteryApplierByUid(uid);
         return MyLinkDto.create(
                 lotteryApplier

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,4 +4,4 @@ spring:
 server:
   port: 8080
   base-url: http://43.202.54.29:8080
-  parts-share-url: watermelon-clap.web.app/share
+  parts-share-url: https://watermelon-clap.web.app/share

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,4 +4,4 @@ spring:
 server:
   port: 8080
   base-url: http://43.202.54.29:8080
-  parts-share-url: https://watermelon-clap.web.app/share
+  parts-share-url: http://localhost:5173/share

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,4 @@ spring:
 server:
   port: 8080
   base-url: http://43.202.54.29:8080
+  parts-share-url: watermelon-clap.web.app/share

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,4 @@ spring:
     active: ${name:local}
 server:
   port: 8080
+  base-url: http://43.202.54.29:8080

--- a/src/test/java/com/watermelon/server/APITest.java
+++ b/src/test/java/com/watermelon/server/APITest.java
@@ -310,7 +310,7 @@ public abstract class APITest {
     protected void thenRedirect() throws Exception {
         resultActions
                 .andExpect(status().isFound())
-                .andExpect(header().string(HEADER_NAME_LOCATION, LinkUtils.makeUrl(TEST_URI)));
+                .andExpect(header().string(HEADER_NAME_LOCATION, TEST_REDIRECTION_URL));
     }
 
     protected void whenLotteryEventCreate() throws Exception {

--- a/src/test/java/com/watermelon/server/ControllerTest.java
+++ b/src/test/java/com/watermelon/server/ControllerTest.java
@@ -197,7 +197,7 @@ public class ControllerTest extends APITest{
     }
 
     protected void givenOriginUri(){
-        Mockito.when(linkService.getUrl(TEST_SHORTED_URI)).thenReturn(TEST_URI);
+        Mockito.when(linkService.getRedirectUrl(TEST_SHORTED_URI)).thenReturn(TEST_REDIRECTION_URL);
     }
 
 }

--- a/src/test/java/com/watermelon/server/ControllerTest.java
+++ b/src/test/java/com/watermelon/server/ControllerTest.java
@@ -192,7 +192,7 @@ public class ControllerTest extends APITest{
     }
 
     protected void givenLink(){
-        Mockito.when(linkService.getMyLink(TEST_UID))
+        Mockito.when(linkService.getShortedLink(TEST_UID))
                 .thenReturn(MyLinkDto.createTestDto());
     }
 

--- a/src/test/java/com/watermelon/server/constants/Constants.java
+++ b/src/test/java/com/watermelon/server/constants/Constants.java
@@ -14,6 +14,7 @@ public class Constants {
     public static final int TEST_PAGE_SIZE = 2;
     public static final String TEST_URI = "aa1d363b-b749-4180-9fe9-c7d21e7631c4";
     public static final String TEST_SHARE_URL = "http://localhost:8080/link/5B02ofbDBtzznrRrZWy7wS";
+    public static final String TEST_REDIRECTION_URL = "https://watermelon-clap.web.app/share/aa1d363b-b749-4180-9fe9-c7d21e7631c4";
     public static final String TEST_SHORTED_URI = "5B02ofbDBtzznrRrZWy7wS";
 
     public static final String HEADER_NAME_AUTHORIZATION = "Authorization";

--- a/src/test/java/com/watermelon/server/constants/Constants.java
+++ b/src/test/java/com/watermelon/server/constants/Constants.java
@@ -12,8 +12,9 @@ public class Constants {
     public static final String TEST_IMGSRC = "imgsrc";
     public static final int TEST_PAGE_NUMBER = 1;
     public static final int TEST_PAGE_SIZE = 2;
-    public static final String TEST_URI = "link";
-    public static final String TEST_SHORTED_URI = "shortedUri";
+    public static final String TEST_URI = "aa1d363b-b749-4180-9fe9-c7d21e7631c4";
+    public static final String TEST_SHARE_URL = "http://localhost:8080/link/5B02ofbDBtzznrRrZWy7wS";
+    public static final String TEST_SHORTED_URI = "5B02ofbDBtzznrRrZWy7wS";
 
     public static final String HEADER_NAME_AUTHORIZATION = "Authorization";
     public static final String HEADER_NAME_LOCATION = "Location";

--- a/src/test/java/com/watermelon/server/event/link/service/LinkServiceImplTest.java
+++ b/src/test/java/com/watermelon/server/event/link/service/LinkServiceImplTest.java
@@ -6,6 +6,7 @@ import com.watermelon.server.event.link.dto.MyLinkDto;
 import com.watermelon.server.event.link.repository.LinkRepository;
 import com.watermelon.server.event.lottery.service.LotteryService;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,9 +14,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
+import static com.watermelon.server.constants.Constants.TEST_SHARE_URL;
 import static com.watermelon.server.constants.Constants.TEST_URI;
 import static com.watermelon.server.auth.service.TestTokenVerifier.TEST_UID;
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,6 +35,11 @@ class LinkServiceImplTest {
     @InjectMocks
     private LinkServiceImpl linkService;
 
+    @BeforeEach
+    void setUp() {
+        // baseUrl 필드에 강제로 값 주입
+        ReflectionTestUtils.setField(linkService, "baseUrl", "http://localhost:8080");
+    }
 
     @Test
     @DisplayName("응모자에 대한 링크를 반환한다.")
@@ -50,7 +58,7 @@ class LinkServiceImplTest {
                 lotteryApplier
         );
 
-        MyLinkDto expected = MyLinkDto.create(TEST_URI);
+        MyLinkDto expected = MyLinkDto.create(TEST_SHARE_URL);
 
         //when
         MyLinkDto actual = linkService.getShortedLink(TEST_UID);

--- a/src/test/java/com/watermelon/server/event/link/service/LinkServiceImplTest.java
+++ b/src/test/java/com/watermelon/server/event/link/service/LinkServiceImplTest.java
@@ -35,7 +35,7 @@ class LinkServiceImplTest {
 
     @Test
     @DisplayName("응모자에 대한 링크를 반환한다.")
-    void getMyLink() {
+    void getShortedLink() {
 
         //given
         LotteryApplier lotteryApplier = LotteryApplier.builder()
@@ -53,7 +53,7 @@ class LinkServiceImplTest {
         MyLinkDto expected = MyLinkDto.create(TEST_URI);
 
         //when
-        MyLinkDto actual = linkService.getMyLink(TEST_UID);
+        MyLinkDto actual = linkService.getShortedLink(TEST_UID);
 
         //then
         assertEquals(expected, actual);

--- a/src/test/java/com/watermelon/server/event/parts/controller/PartsControllerTest.java
+++ b/src/test/java/com/watermelon/server/event/parts/controller/PartsControllerTest.java
@@ -126,7 +126,12 @@ class PartsControllerTest extends ControllerTest {
 
         resultActions
                 .andDo(document(DocumentConstants.PARTS_LINK_LIST,
-                        resourceSnippetAuthed("description")));
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_LINK)
+                                        .description("링크 Uri 의 주인에 대한 파츠 리스트 조회")
+                                        .build()
+                        )));
     }
 
 }

--- a/src/test/java/com/watermelon/server/integration/LinkIntegrationTest.java
+++ b/src/test/java/com/watermelon/server/integration/LinkIntegrationTest.java
@@ -1,7 +1,12 @@
 package com.watermelon.server.integration;
 
+import com.watermelon.server.event.link.utils.LinkUtils;
+import com.watermelon.server.event.lottery.domain.LotteryApplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static com.watermelon.server.auth.service.TestTokenVerifier.TEST_UID;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @DisplayName("[통합] 링크 통합 테스트")
 public class LinkIntegrationTest extends BaseIntegrationTest {
@@ -15,6 +20,25 @@ public class LinkIntegrationTest extends BaseIntegrationTest {
     @Test
     @DisplayName("[예정] 공유한 링크를 통해 컬렉션 페이지에 방문한 사람에게는 장착된 파츠만 전달한다.")
     void test3() {
+
+    }
+
+    @Test
+    @DisplayName("유저의 링크를 조회하면 단축된 링크를 반환한다.")
+    void test4() throws Exception {
+
+        LotteryApplier lotteryApplier = LotteryApplier.createLotteryApplier(TEST_UID);
+        lotteryApplierRepository.save(lotteryApplier);
+
+        String originUrl = lotteryApplier.getLink().getUri();
+
+        String shortedUrl = LinkUtils.toBase62(originUrl);
+
+        whenLinkIsRetrieved();
+
+        resultActions.andExpect(
+                jsonPath("link").value("http://43.202.54.29:8080/link/"+shortedUrl)
+        );
 
     }
 

--- a/src/test/java/com/watermelon/server/integration/LinkIntegrationTest.java
+++ b/src/test/java/com/watermelon/server/integration/LinkIntegrationTest.java
@@ -1,10 +1,14 @@
 package com.watermelon.server.integration;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.watermelon.server.constants.DocumentConstants;
 import com.watermelon.server.event.link.utils.LinkUtils;
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.watermelon.server.auth.service.TestTokenVerifier.TEST_UID;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -39,6 +43,18 @@ public class LinkIntegrationTest extends BaseIntegrationTest {
         resultActions.andExpect(
                 jsonPath("link").value("http://43.202.54.29:8080/link/"+shortedUrl)
         );
+
+    }
+
+    @Test
+    @DisplayName("Uri 포함 주소 리디렉션 - 성공")
+    void redirect() throws Exception {
+
+        givenOriginUri();
+
+        whenRedirect();
+
+        thenRedirect();
 
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   profiles:
     active: local
+server:
+  base-url: http://43.202.54.29:8080

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,4 +3,4 @@ spring:
     active: local
 server:
   base-url: http://43.202.54.29:8080
-  parts-share-url: https://watermelon-clap.web.app/share
+  parts-share-url: http://localhost:5173/share

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,4 +3,4 @@ spring:
     active: local
 server:
   base-url: http://43.202.54.29:8080
-  parts-share-url: http://localhost:5173/share
+  parts-share-url: https://watermelon-clap.web.app/share

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,4 +3,4 @@ spring:
     active: local
 server:
   base-url: http://43.202.54.29:8080
-  parts-share-url: https://watermelon-clap.web.app
+  parts-share-url: https://watermelon-clap.web.app/share

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,3 +3,4 @@ spring:
     active: local
 server:
   base-url: http://43.202.54.29:8080
+  parts-share-url: https://watermelon-clap.web.app


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-214

## 작업 내용
단축 링크를 반환하고 해당 링크로 접속하면 클라이언트의 링크 주소를 띄울 수 있도록 수정했습니다.
