### PR TITLE
기대평 등록 No Value 에러 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ derby.log
 .gradletasknamecache
 /build
 /lottery/build
+/gateway/build
 buildSrc/build
 /spring-*/build
 /framework-*/build

--- a/lottery/src/main/java/com/watermelon/server/auth/interceptor/LoginCheckInterceptor.java
+++ b/lottery/src/main/java/com/watermelon/server/auth/interceptor/LoginCheckInterceptor.java
@@ -27,6 +27,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         log.debug("preHandle");
+
         String token = AuthUtils.parseAuthenticationHeaderValue(
                 request.getHeader(HEADER_AUTHORIZATION)
         );

--- a/lottery/src/main/java/com/watermelon/server/common/config/WebConfig.java
+++ b/lottery/src/main/java/com/watermelon/server/common/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.watermelon.server.common.config;
 import com.watermelon.server.admin.interceptor.AdminAuthorizationInterceptor;
 import com.watermelon.server.auth.interceptor.LoginCheckInterceptor;
 import com.watermelon.server.auth.resolver.UidArgumentResolver;
+import com.watermelon.server.common.interceptor.LoginCheckExpectationPostOnlyInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -20,6 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final UidArgumentResolver uidArgumentResolver;
     private final LoginCheckInterceptor loginCheckInterceptor;
     private final AdminAuthorizationInterceptor adminAuthorizationInterceptor;
+    private final LoginCheckExpectationPostOnlyInterceptor loginCheckExpectationPostOnlyInterceptor;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -37,10 +39,14 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns(PARTS_EQUIP)
                 .addPathPatterns(PARTS_REMAIN)
                 .addPathPatterns(MY_LINK)
-                .addPathPatterns(EXPECTATIONS)
                 .addPathPatterns("/admin/**");
+
+        registry.addInterceptor(loginCheckExpectationPostOnlyInterceptor)
+                        .order(2)
+                                .addPathPatterns(EXPECTATIONS);
+
         registry.addInterceptor(adminAuthorizationInterceptor)
-                .order(2)
+                .order(3)
                 .addPathPatterns("/admin/**");
     }
 

--- a/lottery/src/main/java/com/watermelon/server/common/config/WebConfig.java
+++ b/lottery/src/main/java/com/watermelon/server/common/config/WebConfig.java
@@ -37,6 +37,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns(PARTS_EQUIP)
                 .addPathPatterns(PARTS_REMAIN)
                 .addPathPatterns(MY_LINK)
+                .addPathPatterns(EXPECTATIONS)
                 .addPathPatterns("/admin/**");
         registry.addInterceptor(adminAuthorizationInterceptor)
                 .order(2)

--- a/lottery/src/main/java/com/watermelon/server/common/interceptor/LoginCheckExpectationPostOnlyInterceptor.java
+++ b/lottery/src/main/java/com/watermelon/server/common/interceptor/LoginCheckExpectationPostOnlyInterceptor.java
@@ -1,0 +1,23 @@
+package com.watermelon.server.common.interceptor;
+
+import com.watermelon.server.auth.interceptor.LoginCheckInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginCheckExpectationPostOnlyInterceptor implements HandlerInterceptor {
+
+    private final LoginCheckInterceptor loginCheckInterceptor;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if ("POST".equalsIgnoreCase(request.getMethod())) {
+            return loginCheckInterceptor.preHandle(request, response, handler);
+        }
+        return true; // POST가 아닌 경우에는 인터셉터를 통과시킴
+    }
+}

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/dto/response/ResponseLotteryRankDto.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/dto/response/ResponseLotteryRankDto.java
@@ -12,10 +12,13 @@ public class ResponseLotteryRankDto {
 
     private boolean isApplied;
 
+    private boolean miniature;
+
     public static ResponseLotteryRankDto from(LotteryApplier lotteryApplier) {
         return ResponseLotteryRankDto.builder()
                 .rank(lotteryApplier.getLotteryRank())
                 .isApplied(lotteryApplier.isLotteryApplier())
+                .miniature(lotteryApplier.isPartsWinner())
                 .build();
     }
 
@@ -23,13 +26,39 @@ public class ResponseLotteryRankDto {
         return ResponseLotteryRankDto.builder()
                 .rank(-1)
                 .isApplied(false)
+                .miniature(false)
                 .build();
     }
 
-    public static ResponseLotteryRankDto createAppliedTest(){
+    public static ResponseLotteryRankDto createLotteryWinnerTest(){
         return ResponseLotteryRankDto.builder()
                 .rank(1)
                 .isApplied(true)
+                .miniature(false)
+                .build();
+    }
+
+    public static ResponseLotteryRankDto createAppliedButNotWinnerTest(){
+        return ResponseLotteryRankDto.builder()
+                .rank(-1)
+                .isApplied(true)
+                .miniature(false)
+                .build();
+    }
+
+    public static ResponseLotteryRankDto createPartsWinnerTest(){
+        return ResponseLotteryRankDto.builder()
+                .rank(-1)
+                .isApplied(true)
+                .miniature(true)
+                .build();
+    }
+
+    public static ResponseLotteryRankDto createPartsAndLotteryWinnerTest(){
+        return ResponseLotteryRankDto.builder()
+                .rank(1)
+                .isApplied(true)
+                .miniature(true)
                 .build();
     }
 

--- a/lottery/src/test/java/com/watermelon/server/APITest.java
+++ b/lottery/src/test/java/com/watermelon/server/APITest.java
@@ -4,7 +4,6 @@ package com.watermelon.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.watermelon.server.event.lottery.dto.request.RequestLotteryEventDto;
 import com.watermelon.server.event.lottery.dto.request.RequestLotteryWinnerInfoDto;
-import com.watermelon.server.event.link.utils.LinkUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -64,24 +63,41 @@ public abstract class APITest {
         resultActions = mvc.perform(authedRequest(get("/event/lotteries/rank")));
     }
 
-    protected void thenLotteryAppliersRankIsRetrievedForWinner() throws Exception {
+    protected void thenLotteryAppliersRankIsRetrievedForLotteryWinner() throws Exception {
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("rank").value(TEST_RANK))
-                .andExpect(jsonPath("applied").value(true));
+                .andExpect(jsonPath("applied").value(true))
+                .andExpect(jsonPath("miniature").value(false));
     }
 
     protected void thenLotteryAppliersRankIsRetrievedForApplier() throws Exception {
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("rank").value(-1))
-                .andExpect(jsonPath("applied").value(true));
+                .andExpect(jsonPath("applied").value(true))
+                .andExpect(jsonPath("miniature").value(false));
     }
 
     protected void thenLotteryAppliersRankIsRetrievedWithNoInfo() throws Exception {
         resultActions
                 .andExpect(jsonPath("rank").value(-1))
-                .andExpect(jsonPath("applied").value(false));
+                .andExpect(jsonPath("applied").value(false))
+                .andExpect(jsonPath("miniature").value(false));
+    }
+
+    protected void thenLotteryAppliersRankIsRetrievedForPartsWinner() throws Exception {
+        resultActions
+                .andExpect(jsonPath("rank").value(-1))
+                .andExpect(jsonPath("applied").value(true))
+                .andExpect(jsonPath("miniature").value(true));
+    }
+
+    protected void thenLotteryAppliersRankIsRetrievedForBothWinner() throws Exception {
+        resultActions
+                .andExpect(jsonPath("rank").value(1))
+                .andExpect(jsonPath("applied").value(true))
+                .andExpect(jsonPath("miniature").value(true));
     }
 
     protected void whenLotteryRewardInfoIsRetrieved() throws Exception {

--- a/lottery/src/test/java/com/watermelon/server/ControllerTest.java
+++ b/lottery/src/test/java/com/watermelon/server/ControllerTest.java
@@ -149,12 +149,26 @@ public class ControllerTest extends APITest{
 
     @Override
     protected void givenLotteryApplierApplied() {
-
+        Mockito.when(lotteryService.getLotteryRank(TEST_UID)).thenReturn(
+                ResponseLotteryRankDto.createAppliedButNotWinnerTest()
+        );
     }
 
     protected void givenLotteryWinner(){
         Mockito.when(lotteryService.getLotteryRank(TEST_UID)).thenReturn(
-                ResponseLotteryRankDto.createAppliedTest()
+                ResponseLotteryRankDto.createLotteryWinnerTest()
+        );
+    }
+
+    protected void givenLotteryAndPartsWinner(){
+        Mockito.when(lotteryService.getLotteryRank(TEST_UID)).thenReturn(
+                ResponseLotteryRankDto.createPartsAndLotteryWinnerTest()
+        );
+    }
+
+    protected void givenOnlyPartsWinner(){
+        Mockito.when(lotteryService.getLotteryRank(TEST_UID)).thenReturn(
+                ResponseLotteryRankDto.createPartsWinnerTest()
         );
     }
 

--- a/lottery/src/test/java/com/watermelon/server/event/lottery/controller/LotteryControllerTest.java
+++ b/lottery/src/test/java/com/watermelon/server/event/lottery/controller/LotteryControllerTest.java
@@ -76,7 +76,7 @@ class LotteryControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("응모 정보 반환 - 정보 없음")
+    @DisplayName("응모 정보 반환 - 응모 안했을 경우")
     void testGetLotteryRankNotAppliedCase() throws Exception {
 
         givenLotteryApplierNotExist();
@@ -86,7 +86,7 @@ class LotteryControllerTest extends ControllerTest {
         thenLotteryAppliersRankIsRetrievedWithNoInfo();
 
         resultActions
-                .andDo(document("event/lotteries/rank/success",
+                .andDo(document("응모 안했을 경우",
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag(TAG_LOTTERY)
@@ -96,17 +96,81 @@ class LotteryControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("응모 정보 반환 - 성공")
-    void testGetLotteryRankAppliedCase() throws Exception {
+    @DisplayName("응모 정보 반환 - 추첨 이벤트만 당첨된 경우")
+    void testGetLotteryRankWinnerCase() throws Exception {
 
         givenLotteryWinner();
 
         whenLotteryAppliersRankIsRetrieved();
 
-        thenLotteryAppliersRankIsRetrievedForWinner();
+        thenLotteryAppliersRankIsRetrievedForLotteryWinner();
 
         resultActions
-                .andDo(document("event/lotteries/rank/failure",
+                .andDo(document("추첨 이벤트만 당첨된 경우",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_LOTTERY)
+                                        .description("응모 정보 조회")
+                                        .build()
+                        )));
+
+    }
+
+
+    @Test
+    @DisplayName("응모 정보 반환 - 응모했지만 당첨되지 않은 경우")
+    void testGetLotteryRankAppliedButNotWinnerCase() throws Exception {
+
+        givenLotteryApplierApplied();
+
+        whenLotteryAppliersRankIsRetrieved();
+
+        thenLotteryAppliersRankIsRetrievedForApplier();
+
+        resultActions
+                .andDo(document("응모했지만 당첨되지 않은 경우",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_LOTTERY)
+                                        .description("응모 정보 조회")
+                                        .build()
+                        )));
+
+    }
+
+    @Test
+    @DisplayName("응모 정보 반환 - 파츠 이벤트만 당첨된 경우")
+    void testGetLotteryRankPartsWinnerCase() throws Exception {
+
+        givenOnlyPartsWinner();
+
+        whenLotteryAppliersRankIsRetrieved();
+
+        thenLotteryAppliersRankIsRetrievedForPartsWinner();
+
+        resultActions
+                .andDo(document("파츠 이벤트만 당첨된 경우",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_LOTTERY)
+                                        .description("응모 정보 조회")
+                                        .build()
+                        )));
+
+    }
+
+    @Test
+    @DisplayName("응모 정보 반환 - 추첨, 파츠 둘다 당첨된 경우")
+    void testGetLotteryRankBothWinnerCase() throws Exception {
+
+        givenLotteryAndPartsWinner();
+
+        whenLotteryAppliersRankIsRetrieved();
+
+        thenLotteryAppliersRankIsRetrievedForBothWinner();
+
+        resultActions
+                .andDo(document("추첨, 파츠 둘다 당첨된 경우",
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag(TAG_LOTTERY)

--- a/lottery/src/test/java/com/watermelon/server/integration/LotteryIntegrationTest.java
+++ b/lottery/src/test/java/com/watermelon/server/integration/LotteryIntegrationTest.java
@@ -74,7 +74,7 @@ public class LotteryIntegrationTest extends BaseIntegrationTest {
 
         whenLotteryAppliersRankIsRetrieved();
 
-        thenLotteryAppliersRankIsRetrievedForWinner();
+        thenLotteryAppliersRankIsRetrievedForLotteryWinner();
 
     }
 


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-233

## 작업 내용
가입되지 않은 회원이 기대평 조회 시 에러가 발생하여 회원가입 처리 경로에 기대평을 추가했습니다.

기대평의 Get 요청에 대해서는 로그인 인터셉터를 적용하지 않고, Post 요청에만 적용해야 했는데요, 
인터셉터에 특정 메소드만 설정할 수가 없어서 Post 요청만 처리하는 로그인 인터셉터를 새로 구현했습니다.
관련 내용을 노션에 정리해놓았습니다. 
참고자료 확인 부탁드립니다.

## 참고자료
https://www.notion.so/bside/BE-963197a6016141669fd40c5a689c2c2c
