### PR TITLE
토글 변경사항 저장되도록 @Transactional 추가

### DIFF
--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/ExpectationService.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/ExpectationService.java
@@ -8,6 +8,7 @@ import com.watermelon.server.event.lottery.dto.response.ResponseExpectationDto;
 import com.watermelon.server.event.lottery.error.ExpectationAlreadyExistError;
 import com.watermelon.server.event.lottery.error.ExpectationNotExist;
 import com.watermelon.server.event.lottery.repository.ExpectationRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,8 @@ public class ExpectationService {
                 .map(expectation -> ResponseExpectationDto.forAdmin(expectation))
                 .collect(Collectors.toList());
     }
+
+    @Transactional
     public ResponseAdminExpectationApprovedDto toggleExpectation(Long expectationId) throws ExpectationNotExist {
         Expectation expectation = expectationRepository.findById(expectationId).orElseThrow(ExpectationNotExist::new);
         expectation.toggleApproved();


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-236

## 작업 내용
토글 변경사항 저장되도록 @Transactional 어노테이션을 추가했습니다.
