### PR TITLE
링크 공유 url 수정

### DIFF
--- a/lottery/src/main/resources/application.yml
+++ b/lottery/src/main/resources/application.yml
@@ -3,8 +3,8 @@ spring:
     active: ${name:local}
 server:
   port: 8091
-  base-url: http://43.202.54.29:8080
-  parts-share-url: http://localhost:5173/share
+  base-url: https://softeer.store:8080
+  parts-share-url: https://watermelon-clap.web.app/share
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-266

## 작업 내용
링크 공유 url 을 실제 배포 서버로 수정했습니다.



