### PR TITLE
추첨 어드민 부가기능 추가

### DIFF
--- a/common/src/main/java/com/watermelon/server/auth/service/AuthUserService.java
+++ b/common/src/main/java/com/watermelon/server/auth/service/AuthUserService.java
@@ -1,0 +1,28 @@
+package com.watermelon.server.auth.service;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.UserRecord;
+import com.watermelon.server.auth.exception.AuthenticationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthUserService {
+
+    private final FirebaseAuth firebaseAuth;
+
+    public String getUserEmail(String uid) {
+
+        try {
+            UserRecord userRecord = firebaseAuth.getUserByProviderUid("google.com", uid);
+            return userRecord.getEmail();
+
+        }catch (FirebaseAuthException e) {
+            throw new AuthenticationException();
+        }
+
+    }
+
+}

--- a/common/src/main/java/com/watermelon/server/auth/service/AuthUserService.java
+++ b/common/src/main/java/com/watermelon/server/auth/service/AuthUserService.java
@@ -16,11 +16,11 @@ public class AuthUserService {
     public String getUserEmail(String uid) {
 
         try {
-            UserRecord userRecord = firebaseAuth.getUserByProviderUid("google.com", uid);
+            UserRecord userRecord = firebaseAuth.getUser(uid);
             return userRecord.getEmail();
 
         }catch (FirebaseAuthException e) {
-            throw new AuthenticationException();
+            throw new AuthenticationException(e.getMessage());
         }
 
     }

--- a/lottery/src/main/java/com/watermelon/server/admin/controller/AdminLotteryController.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/controller/AdminLotteryController.java
@@ -3,6 +3,7 @@ package com.watermelon.server.admin.controller;
 import com.watermelon.server.admin.dto.response.ResponseAdminLotteryWinnerDto;
 import com.watermelon.server.admin.dto.response.ResponseAdminPartsWinnerDto;
 import com.watermelon.server.admin.dto.response.ResponseLotteryApplierDto;
+import com.watermelon.server.admin.dto.response.ResponseLotteryEventDto;
 import com.watermelon.server.exception.S3ImageFormatException;
 import com.watermelon.server.event.lottery.dto.request.RequestLotteryEventDto;
 import com.watermelon.server.event.parts.service.PartsService;
@@ -64,6 +65,11 @@ public class AdminLotteryController {
     public ResponseEntity<Void> lottery() {
         lotteryService.lottery();
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/admin/event/lotteries")
+    public ResponseEntity<List<ResponseLotteryEventDto>> getLotteryEvent(){
+        return new ResponseEntity<>(lotteryEventService.getLotteryEvents(), HttpStatus.OK);
     }
 
     @PostMapping("/admin/event/parts")

--- a/lottery/src/main/java/com/watermelon/server/admin/controller/LotteryEventService.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/controller/LotteryEventService.java
@@ -1,5 +1,6 @@
 package com.watermelon.server.admin.controller;
 
+import com.watermelon.server.admin.dto.response.ResponseLotteryEventDto;
 import com.watermelon.server.exception.S3ImageFormatException;
 import com.watermelon.server.event.lottery.dto.request.RequestLotteryEventDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,5 +16,7 @@ public interface LotteryEventService {
      * @throws S3ImageFormatException
      */
     void createLotteryEvent(RequestLotteryEventDto requestLotteryEventDto, List<MultipartFile> images) throws S3ImageFormatException;
+
+    List<ResponseLotteryEventDto> getLotteryEvents();
 
 }

--- a/lottery/src/main/java/com/watermelon/server/admin/controller/LotteryEventServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/controller/LotteryEventServiceImpl.java
@@ -1,5 +1,6 @@
 package com.watermelon.server.admin.controller;
 
+import com.watermelon.server.admin.dto.response.ResponseLotteryEventDto;
 import com.watermelon.server.exception.S3ImageFormatException;
 import com.watermelon.server.S3ImageService;
 import com.watermelon.server.event.lottery.domain.LotteryEvent;
@@ -45,5 +46,10 @@ public class LotteryEventServiceImpl implements LotteryEventService{
 
         lotteryEventRepository.save(lotteryEvent);
 
+    }
+
+    @Override
+    public List<ResponseLotteryEventDto> getLotteryEvents() {
+        return ResponseLotteryEventDto.from(lotteryEventRepository.findAll());
     }
 }

--- a/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminLotteryWinnerDto.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminLotteryWinnerDto.java
@@ -2,6 +2,7 @@ package com.watermelon.server.admin.dto.response;
 
 import com.watermelon.server.event.lottery.domain.AdminCheckStatus;
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
+import com.watermelon.server.event.lottery.domain.LotteryReward;
 import lombok.Builder;
 import lombok.Data;
 
@@ -16,6 +17,7 @@ public class ResponseAdminLotteryWinnerDto {
     private String address;
     private int rank;
     private AdminCheckStatus status;
+    private String reward;
 
     public static ResponseAdminLotteryWinnerDto createTestDto() {
 
@@ -27,11 +29,12 @@ public class ResponseAdminLotteryWinnerDto {
                 .address("address")
                 .rank(1)
                 .status(AdminCheckStatus.READY)
+                .reward("reward")
                 .build();
 
     }
 
-    public static ResponseAdminLotteryWinnerDto from(LotteryApplier lotteryApplier){
+    public static ResponseAdminLotteryWinnerDto from(LotteryApplier lotteryApplier, LotteryReward lotteryReward){
 
         return ResponseAdminLotteryWinnerDto.builder()
                 .uid(lotteryApplier.getUid())
@@ -41,6 +44,7 @@ public class ResponseAdminLotteryWinnerDto {
                 .address(lotteryApplier.getAddress())
                 .rank(lotteryApplier.getLotteryRank())
                 .status(AdminCheckStatus.getStatus(lotteryApplier.isLotteryWinnerCheckedByAdmin()))
+                .reward(lotteryReward.getName())
                 .build();
 
     }

--- a/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminLotteryWinnerDto.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminLotteryWinnerDto.java
@@ -12,6 +12,7 @@ public class ResponseAdminLotteryWinnerDto {
     private String uid;
     private String name;
     private String phoneNumber;
+    private String email;
     private String address;
     private int rank;
     private AdminCheckStatus status;
@@ -22,6 +23,7 @@ public class ResponseAdminLotteryWinnerDto {
                 .uid("uid")
                 .name("name")
                 .phoneNumber("phoneNumber")
+                .email("email")
                 .address("address")
                 .rank(1)
                 .status(AdminCheckStatus.READY)
@@ -35,6 +37,7 @@ public class ResponseAdminLotteryWinnerDto {
                 .uid(lotteryApplier.getUid())
                 .name(lotteryApplier.getName())
                 .phoneNumber(lotteryApplier.getPhoneNumber())
+                .email(lotteryApplier.getEmail())
                 .address(lotteryApplier.getAddress())
                 .rank(lotteryApplier.getLotteryRank())
                 .status(AdminCheckStatus.getStatus(lotteryApplier.isLotteryWinnerCheckedByAdmin()))

--- a/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminPartsWinnerDto.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminPartsWinnerDto.java
@@ -12,6 +12,7 @@ public class ResponseAdminPartsWinnerDto {
     private String uid;
     private String name;
     private String phoneNumber;
+    private String email;
     private String address;
     private int rank;
     private AdminCheckStatus status;
@@ -22,6 +23,7 @@ public class ResponseAdminPartsWinnerDto {
                 .uid("uid")
                 .name("name")
                 .phoneNumber("phoneNumber")
+                .email("email")
                 .address("address")
                 .rank(1)
                 .status(AdminCheckStatus.READY)
@@ -35,6 +37,7 @@ public class ResponseAdminPartsWinnerDto {
                 .uid(lotteryApplier.getUid())
                 .name(lotteryApplier.getName())
                 .phoneNumber(lotteryApplier.getPhoneNumber())
+                .email(lotteryApplier.getEmail())
                 .address(lotteryApplier.getAddress())
                 .rank(1)
                 .status(AdminCheckStatus.getStatus(lotteryApplier.isPartsWinnerCheckedByAdmin()))

--- a/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminPartsWinnerDto.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseAdminPartsWinnerDto.java
@@ -2,6 +2,7 @@ package com.watermelon.server.admin.dto.response;
 
 import com.watermelon.server.event.lottery.domain.AdminCheckStatus;
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
+import com.watermelon.server.event.parts.domain.PartsReward;
 import lombok.Builder;
 import lombok.Data;
 
@@ -16,6 +17,7 @@ public class ResponseAdminPartsWinnerDto {
     private String address;
     private int rank;
     private AdminCheckStatus status;
+    private String reward;
 
     public static ResponseAdminPartsWinnerDto createTestDto() {
 
@@ -26,6 +28,7 @@ public class ResponseAdminPartsWinnerDto {
                 .email("email")
                 .address("address")
                 .rank(1)
+                .reward("reward")
                 .status(AdminCheckStatus.READY)
                 .build();
 
@@ -40,6 +43,7 @@ public class ResponseAdminPartsWinnerDto {
                 .email(lotteryApplier.getEmail())
                 .address(lotteryApplier.getAddress())
                 .rank(1)
+                .reward("아반떼 N 미니어처")
                 .status(AdminCheckStatus.getStatus(lotteryApplier.isPartsWinnerCheckedByAdmin()))
                 .build();
 

--- a/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseLotteryEventDto.java
+++ b/lottery/src/main/java/com/watermelon/server/admin/dto/response/ResponseLotteryEventDto.java
@@ -1,0 +1,28 @@
+package com.watermelon.server.admin.dto.response;
+
+import com.watermelon.server.event.lottery.domain.LotteryEvent;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ResponseLotteryEventDto {
+
+    private String name;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    public static List<ResponseLotteryEventDto> from(List<LotteryEvent> lotteryEvents) {
+        return lotteryEvents.stream().map(
+                lotteryEvent -> new ResponseLotteryEventDto(
+                        lotteryEvent.getName(),
+                        lotteryEvent.getStartTime(),
+                        lotteryEvent.getEndTime()
+                        )
+        ).toList();
+    }
+
+}

--- a/lottery/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
@@ -9,9 +9,11 @@ import com.watermelon.server.event.link.utils.LinkUtils;
 import com.watermelon.server.event.lottery.service.LotteryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LinkServiceImpl implements LinkService {
@@ -41,6 +43,7 @@ public class LinkServiceImpl implements LinkService {
     @Override
     @Transactional
     public void addLinkViewCount(String uri) {
+        log.info("Add link view count: {}", uri);
         Link link = findLink(uri);
         link.addLinkViewCount();
         linkRepository.save(link);

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
@@ -79,11 +79,13 @@ public class LotteryApplier extends BaseEntity {
         this.isPartsWinner = true;
     }
 
-    public void setLotteryReward(LotteryReward reward) {
+    public void lotteryWin(LotteryReward reward, String email) {
+        this.email = email;
         this.lotteryRank = reward.getLotteryRank();
     }
 
-    public void partsLotteryWin(){
+    public void partsLotteryWin(String email){
+        this.email = email;
         this.isPartsWinner = true;
     }
 

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
@@ -76,7 +76,7 @@ public class LotteryApplier extends BaseEntity {
     }
 
     public void partsWinnerCheck(){
-        this.isPartsWinner = true;
+        this.isPartsWinnerCheckedByAdmin = true;
     }
 
     public void lotteryWin(LotteryReward reward, String email) {

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryEvent.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryEvent.java
@@ -38,4 +38,15 @@ public class LotteryEvent extends BaseEntity {
         return event;
     }
 
+    public static LotteryEvent createTest(){
+
+        return LotteryEvent.create(
+                "test",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+
+    }
+
 }

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/repository/LotteryApplierRepository.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/repository/LotteryApplierRepository.java
@@ -4,6 +4,9 @@ import com.watermelon.server.event.lottery.domain.LotteryApplier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,7 +17,11 @@ public interface LotteryApplierRepository extends JpaRepository<LotteryApplier, 
 
     List<LotteryApplier> findByLotteryRankNot(int rank);
 
-    List<LotteryApplier> findByLotteryRankNotOOrderByLotteryRank(int rank);
+    List<LotteryApplier> findByLotteryRankNotOrderByLotteryRank(int rank);
+
+    @Query("UPDATE LotteryApplier l SET l.lotteryRank = :rank")
+    @Modifying
+    void initAllLotteryRank(@Param("rank") int rank);
 
     Optional<LotteryApplier> findByUid(String uid);
 

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/repository/LotteryApplierRepository.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/repository/LotteryApplierRepository.java
@@ -14,6 +14,8 @@ public interface LotteryApplierRepository extends JpaRepository<LotteryApplier, 
 
     List<LotteryApplier> findByLotteryRankNot(int rank);
 
+    List<LotteryApplier> findByLotteryRankNotOOrderByLotteryRank(int rank);
+
     Optional<LotteryApplier> findByUid(String uid);
 
     Page<LotteryApplier> findByIsLotteryApplierTrue(Pageable pageable);

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
@@ -72,11 +72,12 @@ public class LotteryServiceImpl implements LotteryService{
         List<LotteryApplier> lotteryWinners = new ArrayList<>();
 
         int all_count=0;
+        int candidate_count=candidates.size();
 
         //당첨 정보를 설정하고, 당첨자 인원만큼 리스트에 담는다.
         for(LotteryReward reward : rewards){
             int winnerCount = reward.getWinnerCount();
-            for(int i=0; i<winnerCount; i++, all_count++){
+            for(int i=0; i<winnerCount&&all_count<candidate_count; i++, all_count++){
                 LotteryApplier winner = candidates.get(all_count);
                 winner.lotteryWin(reward, authUserService.getUserEmail(winner.getUid()));
                 lotteryWinners.add(winner);

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.watermelon.server.event.lottery.service;
 
 import com.watermelon.server.admin.dto.response.ResponseLotteryApplierDto;
+import com.watermelon.server.auth.service.AuthUserService;
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
 import com.watermelon.server.event.lottery.domain.LotteryReward;
 import com.watermelon.server.event.lottery.dto.response.ResponseLotteryRankDto;
@@ -23,6 +24,7 @@ public class LotteryServiceImpl implements LotteryService{
 
     private final LotteryApplierRepository lotteryApplierRepository;
     private final LotteryRewardRepository lotteryRewardRepository;
+    private final AuthUserService authUserService;
 
     @Override
     public ResponseLotteryRankDto getLotteryRank(String uid) {
@@ -75,7 +77,7 @@ public class LotteryServiceImpl implements LotteryService{
             int winnerCount = reward.getWinnerCount();
             for(int i=0; i<winnerCount; i++, all_count++){
                 LotteryApplier winner = candidates.get(all_count);
-                winner.setLotteryReward(reward);
+                winner.lotteryWin(reward, authUserService.getUserEmail(winner.getUid()));
                 lotteryWinners.add(winner);
             }
         }

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
@@ -10,6 +10,7 @@ import com.watermelon.server.event.lottery.repository.LotteryApplierRepository;
 import com.watermelon.server.event.lottery.repository.LotteryRewardRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LotteryServiceImpl implements LotteryService{
@@ -98,6 +100,7 @@ public class LotteryServiceImpl implements LotteryService{
 
     @Override
     public void registration(String uid) {
+        log.info("registration uid: {}", uid);
         lotteryApplierRepository.save(LotteryApplier.createLotteryApplier(uid));
     }
 

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryServiceImpl.java
@@ -55,6 +55,7 @@ public class LotteryServiceImpl implements LotteryService{
     @Transactional
     @Override
     public void lottery() {
+        lotteryApplierRepository.initAllLotteryRank(-1);
         List<LotteryApplier> candidates = getLotteryCandidates();
         lotteryForCandidates(candidates);
     }

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryWinnerServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryWinnerServiceImpl.java
@@ -61,7 +61,7 @@ public class LotteryWinnerServiceImpl implements LotteryWinnerService{
         Map<Integer, LotteryReward> rankRewardMap = new HashMap<>();
         lotteryRewardRepository.findAll().forEach(r -> rankRewardMap.put(r.getLotteryRank(), r));
 
-        return lotteryApplierRepository.findByLotteryRankNot(NOT_RANKED).stream()
+        return lotteryApplierRepository.findByLotteryRankNotOOrderByLotteryRank(NOT_RANKED).stream()
                 .map(l -> ResponseAdminLotteryWinnerDto.from(l, rankRewardMap.get(l.getLotteryRank())))
                 .collect(Collectors.toList());
     }

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryWinnerServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryWinnerServiceImpl.java
@@ -61,7 +61,7 @@ public class LotteryWinnerServiceImpl implements LotteryWinnerService{
         Map<Integer, LotteryReward> rankRewardMap = new HashMap<>();
         lotteryRewardRepository.findAll().forEach(r -> rankRewardMap.put(r.getLotteryRank(), r));
 
-        return lotteryApplierRepository.findByLotteryRankNotOOrderByLotteryRank(NOT_RANKED).stream()
+        return lotteryApplierRepository.findByLotteryRankNotOrderByLotteryRank(NOT_RANKED).stream()
                 .map(l -> ResponseAdminLotteryWinnerDto.from(l, rankRewardMap.get(l.getLotteryRank())))
                 .collect(Collectors.toList());
     }

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryWinnerServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryWinnerServiceImpl.java
@@ -2,15 +2,19 @@ package com.watermelon.server.event.lottery.service;
 
 import com.watermelon.server.admin.dto.response.ResponseAdminLotteryWinnerDto;
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
+import com.watermelon.server.event.lottery.domain.LotteryReward;
 import com.watermelon.server.event.lottery.dto.request.RequestLotteryWinnerInfoDto;
 import com.watermelon.server.event.lottery.dto.response.ResponseLotteryWinnerDto;
 import com.watermelon.server.event.lottery.dto.response.ResponseLotteryWinnerInfoDto;
 import com.watermelon.server.event.lottery.repository.LotteryApplierRepository;
+import com.watermelon.server.event.lottery.repository.LotteryRewardRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -18,6 +22,7 @@ import java.util.stream.Collectors;
 public class LotteryWinnerServiceImpl implements LotteryWinnerService{
 
     private final LotteryApplierRepository lotteryApplierRepository;
+    private final LotteryRewardRepository lotteryRewardRepository;
 
     private final int NOT_RANKED = -1;
 
@@ -50,9 +55,14 @@ public class LotteryWinnerServiceImpl implements LotteryWinnerService{
     }
 
     @Override
+    @Transactional
     public List<ResponseAdminLotteryWinnerDto> getAdminLotteryWinners() {
+
+        Map<Integer, LotteryReward> rankRewardMap = new HashMap<>();
+        lotteryRewardRepository.findAll().forEach(r -> rankRewardMap.put(r.getLotteryRank(), r));
+
         return lotteryApplierRepository.findByLotteryRankNot(NOT_RANKED).stream()
-                .map(ResponseAdminLotteryWinnerDto::from)
+                .map(l -> ResponseAdminLotteryWinnerDto.from(l, rankRewardMap.get(l.getLotteryRank())))
                 .collect(Collectors.toList());
     }
 

--- a/lottery/src/main/java/com/watermelon/server/event/parts/repository/PartsRepository.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/repository/PartsRepository.java
@@ -2,11 +2,16 @@ package com.watermelon.server.event.parts.repository;
 
 import com.watermelon.server.event.parts.domain.Parts;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PartsRepository extends JpaRepository<Parts, Long> {
 
     @Query("select count(distinct parts.category) from Parts parts")
     long countCategoryDistinct();
+
+    @Query("update LotteryApplier l set l.isPartsWinner = false")
+    @Modifying
+    void updateAllIsPartsWinnerFalse();
 
 }

--- a/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.watermelon.server.event.parts.service;
 
 import com.watermelon.server.admin.dto.response.ResponseAdminPartsWinnerDto;
+import com.watermelon.server.auth.service.AuthUserService;
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
 import com.watermelon.server.event.link.service.LinkService;
 import com.watermelon.server.event.parts.domain.PartsReward;
@@ -35,6 +36,7 @@ public class PartsServiceImpl implements PartsService {
     private final LotteryService lotteryService;
     private final LotteryApplierPartsService lotteryApplierPartsService;
     private final LinkService linkService;
+    private final AuthUserService authUserService;
 
     @Override
     @Transactional //remain chance 를 조회하는 쿼리와 파츠를 저장하는 쿼리 원자성 보장 필요
@@ -136,7 +138,7 @@ public class PartsServiceImpl implements PartsService {
             int winnerCount = reward.getWinnerCount();
             for(int i=0; i<winnerCount; i++, all_count++){
                 LotteryApplier winner = candidates.get(all_count);
-                winner.partsLotteryWin();
+                winner.partsLotteryWin(authUserService.getUserEmail(winner.getUid()));
                 lotteryWinners.add(winner);
             }
         }

--- a/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
@@ -112,6 +112,7 @@ public class PartsServiceImpl implements PartsService {
     @Transactional
     @Override
     public void partsLottery() {
+        partsRepository.updateAllIsPartsWinnerFalse();
         List<LotteryApplier> candidates = getPartsLotteryCandidates();
         partsLotteryForCandidates(candidates);
     }

--- a/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
@@ -133,11 +133,12 @@ public class PartsServiceImpl implements PartsService {
         List<LotteryApplier> lotteryWinners = new ArrayList<>();
 
         int all_count=0;
+        int candidates_count=candidates.size();
 
         //당첨 정보를 설정하고, 당첨자 인원만큼 리스트에 담는다.
         for(PartsReward reward : rewards){
             int winnerCount = reward.getWinnerCount();
-            for(int i=0; i<winnerCount; i++, all_count++){
+            for(int i=0; i<winnerCount&&all_count<candidates_count; i++, all_count++){
                 LotteryApplier winner = candidates.get(all_count);
                 winner.partsLotteryWin(authUserService.getUserEmail(winner.getUid()));
                 lotteryWinners.add(winner);

--- a/lottery/src/test/java/com/watermelon/server/APITest.java
+++ b/lottery/src/test/java/com/watermelon/server/APITest.java
@@ -56,6 +56,8 @@ public abstract class APITest {
     protected abstract void givenExpectationNotExistForLotteryApplier(String uid);
     protected abstract void givenExpectationAlreadyExistForLotteryApplier(String uid);
 
+    protected abstract void givenLotteryEvent();
+
     private MockHttpServletRequestBuilder authedRequest(MockHttpServletRequestBuilder requestBuilder) {
         return requestBuilder
                 .header(HEADER_NAME_AUTHORIZATION, HEADER_VALUE_BEARER + HEADER_VALUE_SPACE + TEST_VALID_TOKEN);
@@ -64,6 +66,17 @@ public abstract class APITest {
     private MockHttpServletRequestBuilder notAuthedRequest(MockHttpServletRequestBuilder requestBuilder) {
         return requestBuilder
                 .header(HEADER_NAME_AUTHORIZATION, HEADER_VALUE_BEARER + HEADER_VALUE_SPACE + TEST_INVALID_TOKEN);
+    }
+
+    protected void whenGetLotteryEvents() throws Exception {
+        resultActions = mvc.perform(authedRequest(get("/admin/event/lotteries")));
+    }
+
+    protected void thenGetLotteryEvents() throws Exception {
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("[0].name").isString())
+                .andExpect(jsonPath("[0].startTime").isString())
+                .andExpect(jsonPath("[0].endTime").isString());
     }
 
     protected void whenCheckLoginNotAuthed() throws Exception {

--- a/lottery/src/test/java/com/watermelon/server/APITest.java
+++ b/lottery/src/test/java/com/watermelon/server/APITest.java
@@ -215,6 +215,7 @@ public abstract class APITest {
                 .andExpect(jsonPath("[0].uid").isString())
                 .andExpect(jsonPath("[0].name").isString())
                 .andExpect(jsonPath("[0].phoneNumber").isString())
+                .andExpect(jsonPath("[0].email").isString())
                 .andExpect(jsonPath("[0].address").isString())
                 .andExpect(jsonPath("[0].rank").isNumber())
                 .andExpect(jsonPath("[0].status").isString());
@@ -229,6 +230,7 @@ public abstract class APITest {
                 .andExpect(jsonPath("[0].uid").isString())
                 .andExpect(jsonPath("[0].name").isString())
                 .andExpect(jsonPath("[0].phoneNumber").isString())
+                .andExpect(jsonPath("[0].email").isString())
                 .andExpect(jsonPath("[0].address").isString())
                 .andExpect(jsonPath("[0].rank").isNumber())
                 .andExpect(jsonPath("[0].status").isString());

--- a/lottery/src/test/java/com/watermelon/server/APITest.java
+++ b/lottery/src/test/java/com/watermelon/server/APITest.java
@@ -218,6 +218,7 @@ public abstract class APITest {
                 .andExpect(jsonPath("[0].email").isString())
                 .andExpect(jsonPath("[0].address").isString())
                 .andExpect(jsonPath("[0].rank").isNumber())
+                .andExpect(jsonPath("[0].reward").isString())
                 .andExpect(jsonPath("[0].status").isString());
     }
 
@@ -233,6 +234,7 @@ public abstract class APITest {
                 .andExpect(jsonPath("[0].email").isString())
                 .andExpect(jsonPath("[0].address").isString())
                 .andExpect(jsonPath("[0].rank").isNumber())
+                .andExpect(jsonPath("[0].reward").isString())
                 .andExpect(jsonPath("[0].status").isString());
     }
 

--- a/lottery/src/test/java/com/watermelon/server/ControllerTest.java
+++ b/lottery/src/test/java/com/watermelon/server/ControllerTest.java
@@ -6,8 +6,10 @@ import com.watermelon.server.admin.controller.LotteryEventService;
 import com.watermelon.server.admin.dto.response.ResponseAdminLotteryWinnerDto;
 import com.watermelon.server.admin.dto.response.ResponseAdminPartsWinnerDto;
 import com.watermelon.server.admin.dto.response.ResponseLotteryApplierDto;
+import com.watermelon.server.admin.dto.response.ResponseLotteryEventDto;
 import com.watermelon.server.config.MockAdminAuthorizationInterceptorConfig;
 import com.watermelon.server.config.MockLoginInterceptorConfig;
+import com.watermelon.server.event.lottery.domain.LotteryEvent;
 import com.watermelon.server.event.lottery.dto.response.*;
 import com.watermelon.server.event.link.dto.MyLinkDto;
 import com.watermelon.server.event.link.service.LinkService;
@@ -42,7 +44,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
 @Import({MockLoginInterceptorConfig.class, MockAdminAuthorizationInterceptorConfig.class})
-public class ControllerTest extends APITest{
+public class ControllerTest extends APITest {
 
     @MockBean
     protected LotteryService lotteryService;
@@ -78,7 +80,7 @@ public class ControllerTest extends APITest{
         );
     }
 
-    protected ResourceSnippet resourceSnippetAuthed(String description){
+    protected ResourceSnippet resourceSnippetAuthed(String description) {
 
         return resource(
                 ResourceSnippetParameters.builder()
@@ -101,7 +103,7 @@ public class ControllerTest extends APITest{
                         ), pageable, TEST_PAGE_SIZE));
     }
 
-    protected void givenPartsWinnerList(){
+    protected void givenPartsWinnerList() {
         Mockito.when(partsService.getAdminPartsWinners())
                 .thenReturn(List.of(
                         ResponseAdminPartsWinnerDto.createTestDto(),
@@ -110,13 +112,13 @@ public class ControllerTest extends APITest{
     }
 
 
-    protected void givenLotteryRewardInfo(){
+    protected void givenLotteryRewardInfo() {
         Mockito.when(lotteryRewardService.getRewardInfo(TEST_RANK)).thenReturn(
                 new ResponseRewardInfoDto(TEST_IMGSRC, TEST_NAME)
         );
     }
 
-    protected void givenLotteryRewardInfoNotExists(){
+    protected void givenLotteryRewardInfoNotExists() {
         Mockito.doThrow(new LotteryRewardNotFoundException())
                 .when(lotteryRewardService).getRewardInfo(TEST_RANK);
     }
@@ -161,25 +163,25 @@ public class ControllerTest extends APITest{
         );
     }
 
-    protected void givenLotteryWinner(){
+    protected void givenLotteryWinner() {
         Mockito.when(lotteryService.getLotteryRank(TEST_UID)).thenReturn(
                 ResponseLotteryRankDto.createLotteryWinnerTest()
         );
     }
 
-    protected void givenLotteryAndPartsWinner(){
+    protected void givenLotteryAndPartsWinner() {
         Mockito.when(lotteryService.getLotteryRank(TEST_UID)).thenReturn(
                 ResponseLotteryRankDto.createPartsAndLotteryWinnerTest()
         );
     }
 
-    protected void givenOnlyPartsWinner(){
+    protected void givenOnlyPartsWinner() {
         Mockito.when(lotteryService.getLotteryRank(TEST_UID)).thenReturn(
                 ResponseLotteryRankDto.createPartsWinnerTest()
         );
     }
 
-    protected void givenPartsListForUri(){
+    protected void givenPartsListForUri() {
         Mockito.when(partsService.getPartsList(TEST_URI)).thenReturn(
                 ResponseMyPartsListDto.createTestDtoList()
         );
@@ -190,16 +192,16 @@ public class ControllerTest extends APITest{
 
     }
 
-    protected void givenEquipPartsNotExist(){
+    protected void givenEquipPartsNotExist() {
         Mockito.doThrow(new PartsNotExistException()).when(partsService)
                 .toggleParts(TEST_UID, TEST_PARTS_ID);
     }
 
-    protected void givenLotteryApplierWhoHasNoRemainChance(){
+    protected void givenLotteryApplierWhoHasNoRemainChance() {
         Mockito.when(partsService.drawParts(TEST_UID)).thenThrow(new PartsDrawLimitExceededException());
     }
 
-    protected void givenLotteryApplierWhoDrawsPartsFirst(){
+    protected void givenLotteryApplierWhoDrawsPartsFirst() {
         Mockito.when(partsService.drawParts(TEST_UID)).thenReturn(
                 ResponsePartsDrawDto.createResponsePartsDrawDtoTest()
         );
@@ -211,18 +213,18 @@ public class ControllerTest extends APITest{
         );
     }
 
-    protected void givenMyPartsList(){
+    protected void givenMyPartsList() {
         Mockito.when(partsService.getMyParts(TEST_UID)).thenReturn(
                 ResponseMyPartsListDto.createTestDtoList()
         );
     }
 
-    protected void givenLink(){
+    protected void givenLink() {
         Mockito.when(linkService.getShortedLink(TEST_UID))
                 .thenReturn(MyLinkDto.createTestDto());
     }
 
-    protected void givenOriginUri(){
+    protected void givenOriginUri() {
         Mockito.when(linkService.getRedirectUrl(TEST_SHORTED_URI)).thenReturn(TEST_REDIRECTION_URL);
     }
 
@@ -237,6 +239,17 @@ public class ControllerTest extends APITest{
     protected void givenExpectationAlreadyExistForLotteryApplier(String uid) {
         Mockito.when(expectationService.isExpectationAlreadyExist(uid)).thenReturn(
                 ResponseExpectationCheckDto.from(true)
+        );
+    }
+
+    @Override
+    protected void givenLotteryEvent() {
+        Mockito.when(lotteryEventService.getLotteryEvents()).thenReturn(
+                ResponseLotteryEventDto.from(
+                        List.of(
+                                LotteryEvent.createTest()
+                        )
+                )
         );
     }
 

--- a/lottery/src/test/java/com/watermelon/server/event/admin/controller/AdminLotteryControllerTest.java
+++ b/lottery/src/test/java/com/watermelon/server/event/admin/controller/AdminLotteryControllerTest.java
@@ -240,7 +240,7 @@ class AdminLotteryControllerTest extends ControllerTest {
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag(TAG_LOTTERY)
-                                        .description("파츠 이벤트 응모자에 대해 추첨")
+                                        .description("추첨 이벤트 조회")
                                         .build()
                         )));
 

--- a/lottery/src/test/java/com/watermelon/server/event/admin/controller/AdminLotteryControllerTest.java
+++ b/lottery/src/test/java/com/watermelon/server/event/admin/controller/AdminLotteryControllerTest.java
@@ -225,4 +225,26 @@ class AdminLotteryControllerTest extends ControllerTest {
 
     }
 
+    @Test
+    @DisplayName("추첨 이벤트 조회")
+    void getLotteryEventsTest() throws Exception {
+
+        givenLotteryEvent();
+
+        whenGetLotteryEvents();
+
+        thenGetLotteryEvents();
+
+        resultActions
+                .andDo(document(DOCUMENT_NAME_PARTS_LOTTERY,
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG_LOTTERY)
+                                        .description("파츠 이벤트 응모자에 대해 추첨")
+                                        .build()
+                        )));
+
+
+    }
+
 }

--- a/lottery/src/test/java/com/watermelon/server/integration/BaseIntegrationTest.java
+++ b/lottery/src/test/java/com/watermelon/server/integration/BaseIntegrationTest.java
@@ -187,4 +187,8 @@ public class BaseIntegrationTest extends APITest {
     protected void givenExpectationAlreadyExistForLotteryApplier(String uid) {
 
     }
+
+    @Override
+    protected void givenLotteryEvent() {
+    }
 }


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?isInsightsOpen=true&selectedIssue=WB-271

## 작업 내용
- [x] 당첨 저장될 때 유저 이메일도 같이 저장.
- [x] 추첨 이벤트 당첨자 목록 조회 시 랭킹에 대한 경품, 이메일도 반환
- [x] 랭킹 순으로 오름차순 정렬 후 반환
- [x] 추첨 시 기존 데이터 날라가도록 수정
- [x] 미니어처도 동일하게 적용
