### PR TITLE
파츠 리스트 조회 성능 개선 (N + 1)

### DIFF
--- a/lottery/src/main/java/com/watermelon/server/event/parts/repository/LotteryApplierPartsRepository.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/repository/LotteryApplierPartsRepository.java
@@ -15,6 +15,9 @@ public interface LotteryApplierPartsRepository extends JpaRepository<LotteryAppl
     List<LotteryApplierParts> findLotteryApplierPartsByLotteryApplierId(Long lotteryApplierId);
     List<LotteryApplierParts> findLotteryApplierPartsByLotteryApplierUid(String lotteryApplierUid);
 
+    @Query("select lap from LotteryApplierParts lap join fetch lap.parts where lap.lotteryApplier.uid = :lotteryApplierUid")
+    List<LotteryApplierParts> findLotteryApplierPartsByLotteryApplierUidFetchJoin(String lotteryApplierUid);
+
     Optional<LotteryApplierParts> findLotteryApplierPartsByLotteryApplierUidAndPartsId(String lotteryApplierUid,Long partsId);
 
     @Query("SELECT COUNT(DISTINCT lap.parts.category) FROM LotteryApplierParts lap WHERE lap.lotteryApplier = :lotteryApplier")

--- a/lottery/src/main/java/com/watermelon/server/event/parts/service/LotteryApplierPartsServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/service/LotteryApplierPartsServiceImpl.java
@@ -80,7 +80,7 @@ public class LotteryApplierPartsServiceImpl implements LotteryApplierPartsServic
 
     @Override
     public List<LotteryApplierParts> getListByApplier(String uid) {
-        return lotteryApplierPartsRepository.findLotteryApplierPartsByLotteryApplierUid(uid);
+        return lotteryApplierPartsRepository.findLotteryApplierPartsByLotteryApplierUidFetchJoin(uid);
     }
 
     /**


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-273

## 작업 내용
파츠 리스트 조회에서 N+1 문제를 개선했습니다.

## 참고자료
https://www.notion.so/bside/BE-N-1-7a9294605ddb4cd2ba5ec84f60b129f1


