### PR TITLE
토클시 기대평 캐시를 초기화 하도록 구현

### DIFF
--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/ExpectationService.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/ExpectationService.java
@@ -11,6 +11,7 @@ import com.watermelon.server.event.lottery.error.ExpectationNotExist;
 import com.watermelon.server.event.lottery.repository.ExpectationRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -58,6 +59,7 @@ public class ExpectationService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = "expectations",allEntries = true)
     public ResponseAdminExpectationApprovedDto toggleExpectation(Long expectationId) throws ExpectationNotExist {
         Expectation expectation = expectationRepository.findById(expectationId).orElseThrow(ExpectationNotExist::new);
         expectation.toggleApproved();


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-282

## 작업 내용
- 관리자가 기대평 토클시 기대평 캐시를 삭제 
```
@Transactional
    @CacheEvict(cacheNames = "expectations",allEntries = true)
    public ResponseAdminExpectationApprovedDto toggleExpectation(Long expectationId) throws ExpectationNotExist {
        Expectation expectation = expectationRepository.findById(expectationId).orElseThrow(ExpectationNotExist::new);
        expectation.toggleApproved();
        return ResponseAdminExpectationApprovedDto.forAdminAfterToggleIsApproved(expectation);
    }
```





