### PR TITLE
fix[api-server]: 링크, 응모자, 응모자-파츠 엔티티 생성전략 IDENTITY로 수정

### DIFF
--- a/lottery/src/main/java/com/watermelon/server/event/lottery/domain/Link.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/domain/Link.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class Link extends BaseEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Builder.Default

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
@@ -15,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 public class LotteryApplier extends BaseEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String uid;

--- a/lottery/src/main/java/com/watermelon/server/event/parts/domain/LotteryApplierParts.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/domain/LotteryApplierParts.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public class LotteryApplierParts extends BaseEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/jira/software/projects/WB/boards/2?selectedIssue=WB-285

## 작업 내용
응모 시 커넥션을 1개만 가져가기 위해 생성전략을 IDENTITY로 수정했습니다.




