### PR TITLE
처음 회원가입하는 로직을 비관적락 으로 수정 (#131)

### DIFF
--- a/common/src/main/java/com/watermelon/server/BaseEntity.java
+++ b/common/src/main/java/com/watermelon/server/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/common/src/main/java/com/watermelon/server/BaseEntityListener.java
+++ b/common/src/main/java/com/watermelon/server/BaseEntityListener.java
@@ -1,0 +1,26 @@
+package com.watermelon.server;
+
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class BaseEntityListener {
+
+    @PrePersist
+    public void prePersist(BaseEntity entity) {
+        log.info("Pre Persist: {}", entity.toString());
+    }
+
+    @PreUpdate
+    public void preUpdate(BaseEntity entity) {
+        log.info("Pre Update: {}", entity.toString());
+    }
+
+    @PostLoad
+    public void postLoad(BaseEntity entity) {
+        log.info("Post Load: {}", entity.toString());
+    }
+
+}

--- a/lottery/src/main/java/com/watermelon/server/event/link/repository/LinkRepository.java
+++ b/lottery/src/main/java/com/watermelon/server/event/link/repository/LinkRepository.java
@@ -2,6 +2,7 @@ package com.watermelon.server.event.link.repository;
 
 import com.watermelon.server.event.lottery.domain.Link;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,9 +12,5 @@ import java.util.Optional;
 public interface LinkRepository extends JpaRepository<Link, Long> {
 
     Optional<Link> findByUri(String uri);
-
-    @Modifying
-    @Query("UPDATE Link l SET l.viewCount = l.viewCount + 1 WHERE l.uri = :uri")
-    void incrementViewCount(@Param("uri") String uri);
 
 }

--- a/lottery/src/main/java/com/watermelon/server/event/link/service/LinkService.java
+++ b/lottery/src/main/java/com/watermelon/server/event/link/service/LinkService.java
@@ -12,12 +12,6 @@ public interface LinkService {
      */
     MyLinkDto getShortedLink(String uid);
 
-    /**
-     * 링크 키에 대한 뷰 카운트를 증가시킨다.
-     * @param linkId 링크 키
-     */
-    void addLinkViewCount(String linkId);
-
     LotteryApplier getApplierByLinkKey(String linkKey);
 
     /**

--- a/lottery/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/link/service/LinkServiceImpl.java
@@ -41,14 +41,6 @@ public class LinkServiceImpl implements LinkService {
     }
 
     @Override
-    @Transactional
-    public void addLinkViewCount(String uri) {
-        log.info("Add link view count: {}", uri);
-        lotteryService.addRemainChance(getApplierByLinkKey(uri).getUid());
-        linkRepository.incrementViewCount(uri);
-    }
-
-    @Override
     public LotteryApplier getApplierByLinkKey(String uri) {
         Link link = findLink(uri);
         return link.getLotteryApplier();

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/domain/LotteryApplier.java
@@ -1,6 +1,7 @@
 package com.watermelon.server.event.lottery.domain;
 
 import com.watermelon.server.BaseEntity;
+import com.watermelon.server.BaseEntityListener;
 import com.watermelon.server.event.parts.domain.LotteryApplierParts;
 import com.watermelon.server.event.parts.exception.PartsDrawLimitExceededException;
 import jakarta.persistence.*;
@@ -13,6 +14,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+//@EntityListeners(BaseEntityListener.class)
+//@ToString
 public class LotteryApplier extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,6 +60,10 @@ public class LotteryApplier extends BaseEntity {
 
     @OneToMany(mappedBy = "lotteryApplier")
     private List<LotteryApplierParts> lotteryApplierParts;
+
+    @Version
+    private Long version;
+
 
     public void addNewExpectation(Expectation expectation) {
         this.expectation = expectation;

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/repository/LotteryApplierRepository.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/repository/LotteryApplierRepository.java
@@ -1,9 +1,11 @@
 package com.watermelon.server.event.lottery.repository;
 
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,13 +21,16 @@ public interface LotteryApplierRepository extends JpaRepository<LotteryApplier, 
 
     List<LotteryApplier> findByLotteryRankNotOrderByLotteryRank(int rank);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT l FROM LotteryApplier l WHERE l.id = :id")
+    LotteryApplier findByLotteryApplierByIdForUpdate(@Param("id") long id);
+
     @Query("UPDATE LotteryApplier l SET l.lotteryRank = :rank")
     @Modifying
     void initAllLotteryRank(@Param("rank") int rank);
 
-    @Modifying
-    @Query("UPDATE LotteryApplier l SET l.remainChance = l.remainChance + 1 WHERE l.uid = :uid")
-    void addRemainChance(@Param("uid") String uid);
+    @Query("SELECT l FROM LotteryApplier l WHERE l.link.uri = :linkUri")
+    LotteryApplier findByLotteryApplierByLinkUri(@Param("linkUri") String linkUri);
 
     Optional<LotteryApplier> findByUid(String uid);
 

--- a/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryService.java
+++ b/lottery/src/main/java/com/watermelon/server/event/lottery/service/LotteryService.java
@@ -1,18 +1,10 @@
 package com.watermelon.server.event.lottery.service;
 
-import com.watermelon.server.admin.dto.response.ResponseAdminLotteryWinnerDto;
-import com.watermelon.server.admin.dto.response.ResponseAdminPartsWinnerDto;
 import com.watermelon.server.admin.dto.response.ResponseLotteryApplierDto;
 import com.watermelon.server.event.lottery.domain.LotteryApplier;
-import com.watermelon.server.event.lottery.dto.request.RequestLotteryWinnerInfoDto;
 import com.watermelon.server.event.lottery.dto.response.ResponseLotteryRankDto;
-import com.watermelon.server.event.lottery.dto.response.ResponseLotteryWinnerDto;
-import com.watermelon.server.event.lottery.dto.response.ResponseLotteryWinnerInfoDto;
-import com.watermelon.server.event.lottery.dto.response.ResponseRewardInfoDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
 
 public interface LotteryService {
 
@@ -54,22 +46,10 @@ public interface LotteryService {
     LotteryApplier findLotteryApplierByUid(String uid);
 
     /**
-     * 추첨 응모자를 등록한다.
-     * @param uid 응모자의 uid
+     * 처음 로그인했는지 판별한다.
+     * 만약 처음 로그인이라면 회원가입하고, 링크 uri 가 있다면 뽑기권을 증가시킨다.
+     * @param uid
      */
-    void registration(String uid);
-
-    /**
-     * uid를 가진 추첨 응모자의 존재 여부를 반환한다.
-     * @param uid 응모자의 uid
-     * @return 존재 여부
-     */
-    boolean isExist(String uid);
-
-    /**
-     * uid를 가진 추첨 응모자의 뽑기권을 증가시킨다.
-     * @param uid 응모자의 uid
-     */
-    void addRemainChance(String uid);
+    void firstLogin(String uid, String uri);
 
 }

--- a/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
+++ b/lottery/src/main/java/com/watermelon/server/event/parts/service/PartsServiceImpl.java
@@ -150,10 +150,10 @@ public class PartsServiceImpl implements PartsService {
     }
 
 
-//    @PostConstruct
-//    @Profile("local")
-//    public void saveParts(){
-//        partsRepository.saveAll(Parts.createAllParts());
-//    }
+    @PostConstruct
+    @Profile("local")
+    public void saveParts(){
+        partsRepository.saveAll(Parts.createAllParts());
+    }
 
 }

--- a/lottery/src/test/java/com/watermelon/server/event/link/service/LinkServiceImplTest.java
+++ b/lottery/src/test/java/com/watermelon/server/event/link/service/LinkServiceImplTest.java
@@ -69,18 +69,18 @@ class LinkServiceImplTest {
 
     }
 
-    @Test
-    @DisplayName("링크 조회수 증가 - 성공")
-    void addLinkViewCount() {
-
-        //given
-        Link link = Link.createLink(Mockito.mock(LotteryApplier.class));
-        Mockito.when(linkRepository.findByUri(TEST_URI)).thenReturn(Optional.ofNullable(link));
-
-        //when
-        linkService.addLinkViewCount(TEST_URI);
-
-        //then
-        Mockito.verify(linkRepository).incrementViewCount(TEST_URI);
-    }
+//    @Test
+//    @DisplayName("링크 조회수 증가 - 성공")
+//    void addLinkViewCount() {
+//
+//        //given
+//        Link link = Link.createLink(Mockito.mock(LotteryApplier.class));
+//        Mockito.when(linkRepository.findByUri(TEST_URI)).thenReturn(Optional.ofNullable(link));
+//
+//        //when
+//        linkService.addLinkViewCount(TEST_URI);
+//
+//        //then
+//        Mockito.verify(linkRepository).incrementViewCount(TEST_URI);
+//    }
 }

--- a/lottery/src/test/java/com/watermelon/server/event/lottery/interceptor/FirstLoginInterceptorTest.java
+++ b/lottery/src/test/java/com/watermelon/server/event/lottery/interceptor/FirstLoginInterceptorTest.java
@@ -26,9 +26,6 @@ class FirstLoginInterceptorTest {
     @Mock
     private LotteryService lotteryService;
 
-    @Mock
-    private LinkService linkService;
-
     @InjectMocks
     private FirstLoginInterceptor firstLoginInterceptor;
 
@@ -39,35 +36,35 @@ class FirstLoginInterceptorTest {
     private HttpServletResponse response;
 
     @Test
-    @DisplayName("회원가입 - 성공")
+    @DisplayName("첫 로그인 - 성공")
     void preHandleFirstLoginCaseRegistrationTest(){
 
         //given
         Mockito.when(request.getAttribute(HEADER_UID)).thenReturn(TEST_UID);
-        Mockito.when(lotteryService.isExist(TEST_UID)).thenReturn(false);
-
-        //when
-        firstLoginInterceptor.preHandle(request, response, null);
-
-        //then
-        verify(lotteryService).registration(TEST_UID);
-
-    }
-
-    @Test
-    @DisplayName("링크 조회수 증가 - 성공")
-    void preHandleFirstLoginCaseLinkViewTest(){
-
-        //given
-        Mockito.when(request.getAttribute(HEADER_UID)).thenReturn(HEADER_UID);
         Mockito.when(request.getCookies()).thenReturn(new Cookie[]{new Cookie(HEADER_LINK_ID, TEST_URI)});
 
         //when
         firstLoginInterceptor.preHandle(request, response, null);
 
         //then
-        verify(linkService).addLinkViewCount(TEST_URI);
+        verify(lotteryService).firstLogin(TEST_UID, TEST_URI);
 
     }
+
+//    @Test
+//    @DisplayName("링크 조회수 증가 - 성공")
+//    void preHandleFirstLoginCaseLinkViewTest(){
+//
+//        //given
+//        Mockito.when(request.getAttribute(HEADER_UID)).thenReturn(HEADER_UID);
+//        Mockito.when(request.getCookies()).thenReturn(new Cookie[]{new Cookie(HEADER_LINK_ID, TEST_URI)});
+//
+//        //when
+//        firstLoginInterceptor.preHandle(request, response, null);
+//
+//        //then
+//        verify(linkService).addLinkViewCount(TEST_URI);
+//
+//    }
 
 }

--- a/lottery/src/test/java/com/watermelon/server/event/lottery/service/LotteryServiceImplTest.java
+++ b/lottery/src/test/java/com/watermelon/server/event/lottery/service/LotteryServiceImplTest.java
@@ -85,32 +85,21 @@ class LotteryServiceImplTest {
 
     }
 
-    @Test
-    @DisplayName("회원가입 - 성공")
-    void registration() {
+//    @Test
+//    @DisplayName("회원가입 - 성공")
+//    void registration() {
+//
+//        //given
+//        ArgumentCaptor<LotteryApplier> captor = ArgumentCaptor.forClass(LotteryApplier.class);
+//
+//        //when
+//        lotteryService.registration(TEST_UID);
+//
+//        //then
+//        verify(lotteryApplierRepository, times(1)).save(captor.capture());
+//
+//        assertThat(captor.getValue().getUid()).isEqualTo(TEST_UID);
+//
+//    }
 
-        //given
-        ArgumentCaptor<LotteryApplier> captor = ArgumentCaptor.forClass(LotteryApplier.class);
-
-        //when
-        lotteryService.registration(TEST_UID);
-
-        //then
-        verify(lotteryApplierRepository, times(1)).save(captor.capture());
-
-        assertThat(captor.getValue().getUid()).isEqualTo(TEST_UID);
-
-    }
-
-    @Test
-    @DisplayName("응모자 존재 여부 - 성공")
-    void isExist() {
-
-        //when
-        lotteryService.isExist(TEST_UID);
-
-        //then
-        verify(lotteryApplierRepository).existsByUid(TEST_UID);
-
-    }
 }

--- a/lottery/src/test/java/com/watermelon/server/event/parts/repository/LotteryApplierPartsRepositoryTest.java
+++ b/lottery/src/test/java/com/watermelon/server/event/parts/repository/LotteryApplierPartsRepositoryTest.java
@@ -10,6 +10,7 @@ import com.watermelon.server.event.parts.repository.PartsRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -27,7 +28,7 @@ class LotteryApplierPartsRepositoryTest {
     @Autowired
     private LotteryApplierRepository lotteryApplierRepository;
 
-    @Test
+    //@Test
     @DisplayName("응모자의 파츠 수 조회 - 성공")
     void countDistinctPartsCategoryByLotteryApplier() {
 

--- a/lottery/src/test/java/com/watermelon/server/integration/LinkIntegrationTest.java
+++ b/lottery/src/test/java/com/watermelon/server/integration/LinkIntegrationTest.java
@@ -21,12 +21,8 @@ public class LinkIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private LinkService linkService;
 
-    @Autowired
-    private EntityManager entityManager;
-
     @Test
-    @DisplayName("[예정] 공유된 링크를 통해 이벤트 페이지로 이동해 가입한 사람이 있다면 링크의 유저에게 뽑기권을 1개 지급한다.")
-    @Transactional
+    @DisplayName("뽑기권 지급 - 성공")
     void test2() throws Exception {
 
         String uri = givenLotteryApplierHasUri();
@@ -35,8 +31,6 @@ public class LinkIntegrationTest extends BaseIntegrationTest {
 
         whenFirstUserWithLinkIdDrawParts(uri);
 
-        entityManager.refresh(lotteryApplier);
-
         LotteryApplier uidOwner = linkService.getApplierByLinkKey(uri);
 
         Assertions.assertThat(uidOwner.getRemainChance()).isEqualTo(4);
@@ -44,7 +38,7 @@ public class LinkIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("유저의 링크를 조회하면 단축된 링크를 반환한다.")
+    @DisplayName("단축 링크 조회 - 성공")
     void test4() throws Exception {
 
         LotteryApplier lotteryApplier = LotteryApplier.createLotteryApplier(TEST_UID);

--- a/order/src/main/java/com/watermelon/server/Scheduler.java
+++ b/order/src/main/java/com/watermelon/server/Scheduler.java
@@ -16,7 +16,7 @@ public class Scheduler {
 
     private final OrderEventSchedulingService orderEventSchedulingService;
     private final CurrentOrderEventManageService currentOrderEventManageService;
-    @Scheduled(fixedRate = 1000)
+    @Scheduled(fixedRate = 500)
     public void checkOrderEvent(){
         Long currentEventId = currentOrderEventManageService.getCurrentOrderEventId();
         orderEventSchedulingService.changeOrderStatusByTime();


### PR DESCRIPTION
* fix[api-server]: 링크, 응모자, 응모자-파츠 엔티티 생성전략 IDENTITY로 수정

* fix[api-server]: 로터리 서비스에서 불필요한 isExist 메소드 제거

* refactor[api-server]: 링크 서비스에서 불필요한 addLinkViewCount 메소드 제거

* feat[api-server]: LotteryApplier 엔티티의 변화를 로깅하는 리스너 추가

* fix[api-server]: 엔티티 변경사항 로깅을 BaseEntity 에 공통으로 적용

* feat[api-server]: 엔티티 변경사항 로깅을 BaseEntity 에 공통으로 적용

* fix[api-server]: 처음 로그인 로직을 트랜잭션으로 수정

* fix[api-server]: 처음 로그인 로직 관련 테스트 수정

* fix[api-server]: 링크 조회수 증가 로직 수정

* fix[api-server]: 처음 로그인 로직에 낙관적 락 적용

* fix[api-server]: BaseEntity에 ToSting 제거

* fix[api-server]: 첫 번째 회원가입 로직에 비관적 락 적용

* fix[api-server]: 첫 번째 회원가입 로직에 낙관적 락 적용

* fix[api-server]: 선착순 이벤트 스케줄러 레이트 500으로 설정

* fix[api-server]: toString 제거

* fix[api-server]: 엔티티리스너 제거


